### PR TITLE
allow building the docs locally

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,13 @@
 using Documenter
 using Pkg: Pkg
+
+# Fix for https://github.com/trixi-framework/Trixi.jl/issues/668
+# to allow building the docs locally
+if (get(ENV, "CI", nothing) != "true") &&
+   (get(ENV, "JULIA_DOC_DEFAULT_ENVIRONMENT", nothing) != "true")
+    push!(LOAD_PATH, dirname(@__DIR__))
+end
+
 using PositiveIntegrators
 
 # Define module-wide setups such that the respective modules are available in doctests


### PR DESCRIPTION
@SKopecz This PR allows building the docs locally. Start Julia in the directory of your local clone of PositiveIntegrators.jl and execute

```julia
julia> using Pkg; Pkg.activate("docs"); Pkg.update()

julia> include("docs/make.jl")
```

Then, you get the local version in `docs/build`; the entry point is `docs/build/index.html`.