### PR TITLE
Use `p_prototype` also in `MPE`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ docs/contributing.md
 # committed for packages, but should be committed for applications that require a static
 # environment.
 Manifest.toml
+
+run
+run/*

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PositiveIntegrators"
 uuid = "d1b20bf0-b083-4985-a874-dc5121669aa5"
 authors = ["Stefan Kopecz, Hendrik Ranocha, and contributors"]
-version = "0.1.4-pre"
+version = "0.1.4"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -233,7 +233,7 @@ function alg_cache(alg::MPE, u, rate_prototype, ::Type{uEltypeNoUnits},
                    dt, reltol, p, calck,
                    ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
     tmp = zero(u)
-    P = zeros(eltype(u), length(u), length(u))
+    P = p_prototype(u, f)
     linsolve_tmp = zero(u)
 
     weight = similar(u, uEltypeNoUnits)


### PR DESCRIPTION
In https://github.com/SKopecz/PositiveIntegrators.jl/pull/48, `p_prototype` is used for `MPRK22`, but not for `MPE`. However, I think we could also use the prototype for `MPE` to get some performance improvement, e.g. for `Tridiagonal` matrices, there. With this change, I was able to reduce the time from ~15 ms to ~5 ms for an equation with `Tridiagonal`structure.