### PR TITLE
enable Codecov token for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,6 +41,9 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           file: lcov.info
+          fail_ci_if_error: true
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
       # The standard setup of Coveralls is just annoying for parallel builds, see, e.g.,
       # https://github.com/trixi-framework/Trixi.jl/issues/691
       # https://github.com/coverallsapp/github-action/issues/47


### PR DESCRIPTION
Closes #65 

We need to remember to set the `CODECOV_TOKEN` as repository secret and as secret for Dependabot.
