### PR TITLE
Avoid too many build_mprk_matrix! methods

### DIFF
--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -49,14 +49,14 @@ function build_mprk_matrix(P, sigma, dt)
 end
 
 # in-place for dense arrays
-function build_mprk_matrix!(M, a, P, D, sigma, dt)
+function build_mprk_matrix!(M, P, sigma, dt)
     # M[i,i] = (sigma[i] + dt * sum_j P[j,i]) / sigma[i]
     # M[i,j] = -dt * P[i,j] / sigma[j]
     # TODO: the performance of this can likely be improved
-    Base.require_one_based_indexing(M, P, D, sigma)
-    @assert size(M, 1) == size(M, 2) == size(P, 1) == size(P, 2) == length(D) ==
-            length(sigma)
+    Base.require_one_based_indexing(M, P, sigma)
+    @assert size(M, 1) == size(M, 2) == size(P, 1) == size(P, 2) == length(sigma)
 
+    #=
     for j in 1:length(sigma)
         for i in 1:length(sigma)
             if i == j
@@ -66,10 +66,38 @@ function build_mprk_matrix!(M, a, P, D, sigma, dt)
             end
         end
     end
+    =#
 
-    return M
+    zeroM = zero(eltype(P))
+
+    # Set sigma on diagonal
+    @inbounds for i in eachindex(sigma)
+        M[i, i] = sigma[i]
+    end
+
+    # Run through P and fill M accordingly.
+    # If P[i,j] ≠ 0 set M[i,j] = -dt*P[i,j] and add dt*P[i,j] to M[j,j].
+    @fastmath @inbounds @simd for I in CartesianIndices(P)
+        if I[1] != I[2]
+            if !iszero(P[I])
+                dtP = dt * P[I]
+                M[I] = -dtP / sigma[I[2]]
+                M[I[2], I[2]] += dtP
+            else
+                M[I] = zeroM
+            end
+        end
+    end
+
+    # Divide diagonal elements by Patankar weights denominators
+    @fastmath @inbounds @simd for i in eachindex(sigma)
+        M[i, i] /= sigma[i]
+    end
+
+    return nothing
 end
 
+#=
 function build_mprk_matrix!(M, b1, P1, D1, b2, P2, D2, sigma, dt)
     # M[i,i] = (sigma[i] + dt * sum_j P[j,i]) / sigma[i]
     # M[i,j] = -dt * P[i,j] / sigma[j]
@@ -90,21 +118,19 @@ function build_mprk_matrix!(M, b1, P1, D1, b2, P2, D2, sigma, dt)
 
     return M
 end
+=#
 
 # optimized versions for Tridiagonal matrices
-function build_mprk_matrix!(M::Tridiagonal,
-                            a, P::Tridiagonal, D,
-                            sigma, dt)
+function build_mprk_matrix!(M::Tridiagonal, P::Tridiagonal, σ, dt)
     # M[i,i] = (sigma[i] + dt * sum_j P[j,i]) / sigma[i]
     # M[i,j] = -dt * P[i,j] / sigma[j]
     Base.require_one_based_indexing(M.dl, M.d, M.du,
-                                    P.dl, P.d, P.du,
-                                    D, sigma)
+                                    P.dl, P.d, P.du, σ)
     @assert length(M.dl) + 1 == length(M.d) == length(M.du) + 1 ==
-            length(P.dl) + 1 == length(P.d) == length(P.du) + 1 ==
-            length(D) == length(sigma)
+            length(P.dl) + 1 == length(P.d) == length(P.du) + 1 == length(σ)
 
-    factor = a * dt
+    #=
+    factor = dt
 
     for i in eachindex(M.d, D, sigma)
         M.d[i] = 1 + factor * D[i] / sigma[i]
@@ -117,8 +143,29 @@ function build_mprk_matrix!(M::Tridiagonal,
     for i in eachindex(M.dl, P.dl)
         M.du[i] = -factor * P.du[i] / sigma[i + 1]
     end
+    =#
 
-    return M
+    for i in eachindex(M.d, σ)
+        M.d[i] = σ[i]
+    end
+
+    for i in eachindex(M.dl, P.dl)
+        dtP = dt * P.dl[i]
+        M.dl[i] = -dtP / σ[i]
+        M.d[i] += dtP
+    end
+
+    for i in eachindex(M.du, P.du)
+        dtP = dt * P.du[i]
+        M.du[i] = -dtP / σ[i + 1]
+        M.d[i + 1] += dtP
+    end
+
+    for i in eachindex(M.d, σ)
+        M.d[i] /= σ[i]
+    end
+
+    return nothing
 end
 
 function build_mprk_matrix!(M::Tridiagonal,
@@ -379,10 +426,10 @@ function perform_step!(integrator, cache::MPECache, repeat_step = false)
     fill!(P, zero(eltype(P)))
 
     f.p(P, uprev, p, t) # evaluate production terms
-    sum_destruction_terms!(D, P) # store destruction terms in D
     integrator.stats.nf += 1
 
-    build_mprk_matrix!(P, 1, P, D, uprev, dt)
+    build_mprk_matrix!(P, P, uprev, dt)
+
     # Same as linres = P \ uprev
     linres = dolinsolve(integrator, cache.linsolve;
                         A = P, b = _vec(uprev),
@@ -664,39 +711,46 @@ function perform_step!(integrator, cache::MPRK22Cache, repeat_step = false)
     @unpack tmp, atmp, P, P2, D, D2, M, σ, thread, weight = cache
     @unpack a21, b1, b2, c2, small_constant = cache.tab
 
-    uprev .= uprev .+ small_constant
-
     f.p(P, uprev, p, t) # evaluate production terms
-    sum_destruction_terms!(D, P) # store destruction terms in D
     integrator.stats.nf += 1
+    @.. broadcast=false P2=a21 * P
 
-    build_mprk_matrix!(M, a21, P, D, uprev, dt)
-    # Same as linres = M \ uprev
+    # avoid division by zero due to zero Patankar weights
+    @.. broadcast=false σ=uprev + small_constant
+
+    build_mprk_matrix!(P2, P2, σ, dt)
+
+    # Same as linres = P2 \ uprev
     linres = dolinsolve(integrator, cache.linsolve;
-                        A = M, b = _vec(uprev),
+                        A = P2, b = _vec(uprev),
                         du = integrator.fsalfirst, u = u, p = p, t = t,
                         weight = weight)
     u .= linres
     integrator.stats.nsolve += 1
 
-    u .= u .+ small_constant
-
-    σ .= uprev .* (u ./ uprev) .^ (1 / a21) .+ small_constant
+    if isone(a21)
+        σ .= u
+    else
+        @.. broadcast=false σ=σ^(1 - 1 / a21) * u^(1 / a21)
+    end
+    @.. broadcast=false σ=σ + small_constant
 
     f.p(P2, u, p, t + a21 * dt) # evaluate production terms
-    sum_destruction_terms!(D, P) # store destruction terms in D
-    sum_destruction_terms!(D2, P2) # store destruction terms in D2
+    integrator.stats.nf += 1
 
-    build_mprk_matrix!(M, b1, P, D, b2, P2, D2, σ, dt)
+    @.. broadcast=false P2=b1 * P + b2 * P2
+
+    build_mprk_matrix!(P2, P2, σ, dt)
+
     # Same as linres = M \ uprev
     linres = dolinsolve(integrator, cache.linsolve;
-                        A = M, b = _vec(uprev),
+                        A = P2, b = _vec(uprev),
                         du = integrator.fsalfirst, u = u, p = p, t = t,
                         weight = weight)
     u .= linres
     integrator.stats.nsolve += 1
 
-    tmp .= u .- σ
+    @.. broadcast=false tmp=u - σ
     calculate_residuals!(atmp, tmp, uprev, u, integrator.opts.abstol,
                          integrator.opts.reltol, integrator.opts.internalnorm, t,
                          thread)
@@ -1062,3 +1116,245 @@ function _ode_interpolant!(out, Θ, dt, u0, u1, k,
                            differential_vars::Nothing)
     linear_interpolant!(out, Θ, dt, u0, u1, idxs, T)
 end
+
+### MPRK22_old ################################################################
+struct MPRK22_old{T, Thread, F} <: OrdinaryDiffEqAdaptiveAlgorithm
+    alpha::T
+    thread::Thread
+    linsolve::F
+end
+
+function MPRK22_old(alpha; thread = False(), linsolve = LUFactorization())
+    MPRK22_old{typeof(alpha), typeof(thread), typeof(linsolve)}(alpha, thread, linsolve)
+end
+
+# TODO: Consider switching to the interface of LinearSolve.jl directly,
+#       avoiding `dolinesolve` from OrdinaryDiffEq.jl.
+# TODO: Think about adding preconditioners to the MPRK22 algorithm
+# This hack is currently required to make OrdinaryDiffEq.jl happy...
+function Base.getproperty(alg::MPRK22_old, f::Symbol)
+    # preconditioners
+    if f === :precs
+        return Returns((nothing, nothing))
+    else
+        return getfield(alg, f)
+    end
+end
+
+alg_order(::MPRK22_old) = 2
+isfsal(::MPRK22_old) = false
+
+struct MPRK22_oldCache{uType, rateType, PType, tabType, Thread, F, uNoUnitsType} <:
+       OrdinaryDiffEqMutableCache
+    u::uType
+    uprev::uType
+    tmp::uType
+    atmp::uType
+    k::rateType
+    fsalfirst::rateType
+    P::PType
+    P2::PType
+    D::uType
+    D2::uType
+    M::PType
+    σ::uType
+    tab::tabType
+    thread::Thread
+    linsolve_tmp::uType  # stores rhs of linear system
+    linsolve::F
+    weight::uNoUnitsType
+end
+
+function alg_cache(alg::MPRK22_old, u, rate_prototype, ::Type{uEltypeNoUnits},
+                   ::Type{uBottomEltypeNoUnits}, ::Type{tTypeNoUnits},
+                   uprev, uprev2, f, t, dt, reltol, p, calck,
+                   ::Val{true}) where {uEltypeNoUnits, uBottomEltypeNoUnits, tTypeNoUnits}
+    tab = MPRK22ConstantCache(alg.alpha, 1 - 1 / (2 * alg.alpha), 1 / (2 * alg.alpha),
+                              alg.alpha, floatmin(uEltypeNoUnits))
+
+    tmp = zero(u)
+
+    M = p_prototype(u, f)
+    linsolve_tmp = zero(u)
+    weight = similar(u, uEltypeNoUnits)
+    recursivefill!(weight, false)
+
+    linprob = LinearProblem(M, _vec(linsolve_tmp); u0 = _vec(tmp))
+    linsolve = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
+                    assumptions = LinearSolve.OperatorAssumptions(true))
+
+    MPRK22_oldCache(u, uprev, tmp,
+                    zero(u), # atmp
+                    zero(rate_prototype), # k
+                    zero(rate_prototype), #fsalfirst
+                    p_prototype(u, f), # P
+                    p_prototype(u, f), # P2
+                    zero(u), # D
+                    zero(u), # D2
+                    M,
+                    zero(u), # σ
+                    tab, alg.thread,
+                    linsolve_tmp, linsolve, weight)
+end
+
+function initialize!(integrator, cache::MPRK22_oldCache)
+    @unpack k, fsalfirst = cache
+    integrator.fsalfirst = fsalfirst
+    integrator.fsallast = k
+    integrator.kshortsize = 1
+    resize!(integrator.k, integrator.kshortsize)
+    integrator.k[1] = integrator.fsalfirst
+end
+
+function perform_step!(integrator, cache::MPRK22_oldCache, repeat_step = false)
+    @unpack t, dt, uprev, u, f, p = integrator
+    @unpack tmp, atmp, P, P2, D, D2, M, σ, thread, weight = cache
+    @unpack a21, b1, b2, c2, small_constant = cache.tab
+
+    uprev .= uprev .+ small_constant
+
+    f.p(P, uprev, p, t) # evaluate production terms
+    sum_destruction_terms!(D, P) # store destruction terms in D
+    integrator.stats.nf += 1
+
+    build_mprk_matrix_old!(M, a21, P, D, uprev, dt)
+    # Same as linres = M \ uprev
+    linres = dolinsolve(integrator, cache.linsolve;
+                        A = M, b = _vec(uprev),
+                        du = integrator.fsalfirst, u = u, p = p, t = t,
+                        weight = weight)
+    u .= linres
+    integrator.stats.nsolve += 1
+
+    u .= u .+ small_constant
+
+    σ .= uprev .* (u ./ uprev) .^ (1 / a21) .+ small_constant
+
+    f.p(P2, u, p, t + a21 * dt) # evaluate production terms
+    sum_destruction_terms!(D, P) # store destruction terms in D
+    sum_destruction_terms!(D2, P2) # store destruction terms in D2
+
+    build_mprk_matrix_old!(M, b1, P, D, b2, P2, D2, σ, dt)
+    # Same as linres = M \ uprev
+    linres = dolinsolve(integrator, cache.linsolve;
+                        A = M, b = _vec(uprev),
+                        du = integrator.fsalfirst, u = u, p = p, t = t,
+                        weight = weight)
+    u .= linres
+    integrator.stats.nsolve += 1
+
+    tmp .= u .- σ
+    calculate_residuals!(atmp, tmp, uprev, u, integrator.opts.abstol,
+                         integrator.opts.reltol, integrator.opts.internalnorm, t,
+                         thread)
+    integrator.EEst = integrator.opts.internalnorm(atmp, t)
+end
+
+# in-place for dense arrays
+function build_mprk_matrix_old!(M, a, P, D, sigma, dt)
+    # M[i,i] = (sigma[i] + dt * sum_j P[j,i]) / sigma[i]
+    # M[i,j] = -dt * P[i,j] / sigma[j]
+    # TODO: the performance of this can likely be improved
+    Base.require_one_based_indexing(M, P, D, sigma)
+    @assert size(M, 1) == size(M, 2) == size(P, 1) == size(P, 2) == length(D) ==
+            length(sigma)
+
+    for j in 1:length(sigma)
+        for i in 1:length(sigma)
+            if i == j
+                M[i, i] = 1 + dt * a * D[i] / sigma[i]
+            else
+                M[i, j] = -dt * a * P[i, j] / sigma[j]
+            end
+        end
+    end
+
+    return M
+end
+
+function build_mprk_matrix_old!(M, b1, P1, D1, b2, P2, D2, sigma, dt)
+    # M[i,i] = (sigma[i] + dt * sum_j P[j,i]) / sigma[i]
+    # M[i,j] = -dt * P[i,j] / sigma[j]
+    # TODO: the performance of this can likely be improved
+    Base.require_one_based_indexing(M, P1, D1, P2, D2, sigma)
+    @assert size(M, 1) == size(M, 2) == size(P1, 1) == size(P1, 2) == length(D1) ==
+            size(P2, 1) == size(P2, 2) == length(D1) == length(sigma)
+
+    for j in 1:length(sigma)
+        for i in 1:length(sigma)
+            if i == j
+                M[i, i] = 1 + dt * (b1 * D1[i] + b2 * D2[i]) / sigma[i]
+            else
+                M[i, j] = -dt * (b1 * P1[i, j] + b2 * P2[i, j]) / sigma[j]
+            end
+        end
+    end
+
+    return M
+end
+
+# optimized versions for Tridiagonal matrices
+function build_mprk_matrix_old!(M::Tridiagonal,
+                                a, P::Tridiagonal, D,
+                                sigma, dt)
+    # M[i,i] = (sigma[i] + dt * sum_j P[j,i]) / sigma[i]
+    # M[i,j] = -dt * P[i,j] / sigma[j]
+    Base.require_one_based_indexing(M.dl, M.d, M.du,
+                                    P.dl, P.d, P.du,
+                                    D, sigma)
+    @assert length(M.dl) + 1 == length(M.d) == length(M.du) + 1 ==
+            length(P.dl) + 1 == length(P.d) == length(P.du) + 1 ==
+            length(D) == length(sigma)
+
+    factor = a * dt
+
+    for i in eachindex(M.d, D, sigma)
+        M.d[i] = 1 + factor * D[i] / sigma[i]
+    end
+
+    for i in eachindex(M.dl, P.dl)
+        M.dl[i] = -factor * P.dl[i] / sigma[i]
+    end
+
+    for i in eachindex(M.dl, P.dl)
+        M.du[i] = -factor * P.du[i] / sigma[i + 1]
+    end
+
+    return M
+end
+
+function build_mprk_matrix_old!(M::Tridiagonal,
+                                b1, P1::Tridiagonal, D1,
+                                b2, P2::Tridiagonal, D2,
+                                sigma, dt)
+    # M[i,i] = (sigma[i] + dt * sum_j P[j,i]) / sigma[i]
+    # M[i,j] = -dt * P[i,j] / sigma[j]
+    Base.require_one_based_indexing(M.dl, M.d, M.du,
+                                    P1.dl, P1.d, P1.du, D1,
+                                    P2.dl, P2.d, P2.du, D2,
+                                    sigma)
+    @assert length(M.dl) + 1 == length(M.d) == length(M.du) + 1 ==
+            length(P1.dl) + 1 == length(P1.d) == length(P1.du) + 1 ==
+            length(D1) ==
+            length(P2.dl) + 1 == length(P2.d) == length(P2.du) + 1 ==
+            length(D2) == length(sigma)
+
+    factor1 = b1 * dt
+    factor2 = b2 * dt
+
+    for i in eachindex(M.d, D1, D2, sigma)
+        M.d[i] = 1 + (factor1 * D1[i] + factor2 * D2[i]) / sigma[i]
+    end
+
+    for i in eachindex(M.dl, P1.dl, P2.dl)
+        M.dl[i] = -(factor1 * P1.dl[i] + factor2 * P2.dl[i]) / sigma[i]
+    end
+
+    for i in eachindex(M.dl, P1.du, P2.du)
+        M.du[i] = -(factor1 * P1.du[i] + factor2 * P2.du[i]) / sigma[i + 1]
+    end
+
+    return M
+end
+
+###############################################################################


### PR DESCRIPTION
**WORK IN PROGRESS**

- MPRK22_old uses old implementation

- MPRK22 now uses a single method of build_mprk_matrix! per data type

- Benchmarks show that the new implementation is not slower than the old one

Benchmark 1:
```julia
julia> function linmodP!(P, u, p, t)
           P .= 0
           P[1, 2] = u[2]
           P[2, 1] = 5.0 * u[1]
           return nothing
       end
linmodP! (generic function with 1 method)

julia> prob_ip = ConservativePDSProblem(linmodP!, [0.9, 0.1], (0.0, 2.0), [5.0, 1.0])
ODEProblem with uType Vector{Float64} and tType Float64. In-place: true
timespan: (0.0, 2.0)
u0: 2-element Vector{Float64}:
 0.9
 0.1

julia> sol_ip = solve(prob_ip, MPRK22(1.0), dt = 0.25);

julia> sol_ip_old = solve(prob_ip, PositiveIntegrators.MPRK22_old(1.0), dt = 0.25);

julia> @assert sol_ip.u ≈ sol_ip_old.u

julia> @benchmark solve($prob_ip, $MPRK22(1.0), dt = 0.01, adaptive = false, save_everystep = false)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  154.778 μs …   5.872 ms  ┊ GC (min … max): 0.00% … 95.70%
 Time  (median):     167.608 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   177.819 μs ± 127.052 μs  ┊ GC (mean ± σ):  1.80% ±  2.53%

  ▆▆▇██▆▅▄▄▃▃▂▂▂▁                                               ▂
  ██████████████████████▇█▇▇▇▇██▇▇▇▇▆▆▆▆▆▆▆▆▅▆▆▆▆▃▃▅▆▄▁▄▆▅▅▆▆▅▅ █
  155 μs        Histogram: log(frequency) by time        346 μs <

 Memory estimate: 35.11 KiB, allocs estimate: 441.

julia> @benchmark solve($prob_ip, $PositiveIntegrators.MPRK22_old(1.0), dt = 0.01, adaptive = false,
                        save_everystep = false)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  177.277 μs …   5.200 ms  ┊ GC (min … max): 0.00% … 91.24%
 Time  (median):     197.533 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   207.737 μs ± 121.351 μs  ┊ GC (mean ± σ):  1.44% ±  2.50%

  ▄▄▅▆██▆▄▄▃▂▂▁                                                 ▂
  ███████████████▇██▇▇▇█▇▇▇▇▆▆▆▆▆▆▇▆▆▆▅▆▃▅▅▂▄▄▅▄▄▄▅▃▄▅▄▃▄▄▄▅▃▄▄ █
  177 μs        Histogram: log(frequency) by time        410 μs <

 Memory estimate: 35.12 KiB, allocs estimate: 442.
```

Benchmark 2:
```julia
julia> n = 100
100

julia> P_tridiagonal = Tridiagonal(zeros(n - 1), zeros(n), zeros(n - 1));

julia> u0 = collect(range(1.0,100.0,n));

julia> prod_1! = (P, u, p, t) -> begin
           fill!(P, zero(eltype(P)))
           for i in 1:(length(u) - 1)
               P[i, i + 1] = i * u[i]
           end
           return nothing
       end
#11 (generic function with 1 method)

julia> prob_tridiagonal_ip = ConservativePDSProblem(prod_1!, u0, (0.0, 1.0); p_prototype = P_tridiagonal);

julia> @benchmark solve($prob_tridiagonal_ip, $MPRK22(1.0), dt = 0.1, adaptive = false, save_everystep = false)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  59.774 μs …  2.352 ms  ┊ GC (min … max): 0.00% … 80.07%
 Time  (median):     62.438 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   68.431 μs ± 44.997 μs  ┊ GC (mean ± σ):  1.87% ±  3.13%

  ▇█▆▄▂▁▁▁▃▃▂▂▁▁                                              ▂
  ████████████████████▆█▇█▆▇▆▆▆▆▆▆▇▆▆▆▆▆▆▆▅▅▅▆▄▅▆▅▄▃▁▅▄▃▃▃▁▅▅ █
  59.8 μs      Histogram: log(frequency) by time       156 μs <

 Memory estimate: 59.66 KiB, allocs estimate: 113.

julia> @benchmark solve($prob_tridiagonal_ip, $PositiveIntegrators.MPRK22_old(1.0), dt = 0.1, adaptive = false, save_everystep = false)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  60.218 μs …  1.393 ms  ┊ GC (min … max): 0.00% … 92.86%
 Time  (median):     63.247 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   69.790 μs ± 44.118 μs  ┊ GC (mean ± σ):  1.85% ±  3.16%

  ▇█▆▄▂▁▂▃▃▂▂▁▁▁                                              ▂
  ██████████████████▇█▆█▇▆▇▆▇▆▆▆▅▅▃▅▅▆▆▅▁▅▅▅▄▁▄▅▄▅▅▄▄▄▅▃▄▃▃▃▅ █
  60.2 μs      Histogram: log(frequency) by time       178 μs <

 Memory estimate: 59.67 KiB, allocs estimate: 114.
```

I think we can get rid of the old implementation. What do you think @ranocha ?