### PR TITLE
Sk/mpe caches

### DIFF
--- a/src/PositiveIntegrators.jl
+++ b/src/PositiveIntegrators.jl
@@ -22,7 +22,7 @@ using OrdinaryDiffEq: OrdinaryDiffEq, OrdinaryDiffEqAlgorithm
 
 using SymbolicIndexingInterface
 
-using LinearSolve: LinearSolve, LinearProblem, LUFactorization
+using LinearSolve: LinearSolve, LinearProblem, LUFactorization, solve!
 
 using SciMLBase: DEFAULT_OBSERVED
 import SciMLBase: interp_summary,

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -279,8 +279,6 @@ function perform_step!(integrator, cache::MPEConstantCache, repeat_step = false)
 end
 
 struct MPECache{uType, rateType, PType, F, uNoUnitsType} <: OrdinaryDiffEqMutableCache
-    u::uType
-    uprev::uType
     tmp::uType
     k::rateType
     fsalfirst::rateType
@@ -293,8 +291,6 @@ end
 
 struct MPEConservativeCache{uType, rateType, PType, F, uNoUnitsType} <:
        OrdinaryDiffEqMutableCache
-    u::uType
-    uprev::uType
     tmp::uType
     k::rateType
     fsalfirst::rateType
@@ -321,7 +317,7 @@ function alg_cache(alg::MPE, u, rate_prototype, ::Type{uEltypeNoUnits},
         linsolve = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
                         assumptions = LinearSolve.OperatorAssumptions(true))
 
-        MPEConservativeCache(u, uprev, tmp,
+        MPEConservativeCache(tmp,
                              zero(rate_prototype), # k
                              zero(rate_prototype), # fsalfirst
                              P,
@@ -333,7 +329,7 @@ function alg_cache(alg::MPE, u, rate_prototype, ::Type{uEltypeNoUnits},
         linsolve = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
                         assumptions = LinearSolve.OperatorAssumptions(true))
 
-        MPECache(u, uprev, tmp,
+        MPECache(tmp,
                  zero(rate_prototype), # k
                  zero(rate_prototype), # fsalfirst
                  P,

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -279,7 +279,6 @@ function perform_step!(integrator, cache::MPEConstantCache, repeat_step = false)
 end
 
 struct MPECache{uType, rateType, PType, F, uNoUnitsType} <: OrdinaryDiffEqMutableCache
-    tmp::uType
     k::rateType
     fsalfirst::rateType
     P::PType
@@ -291,7 +290,6 @@ end
 
 struct MPEConservativeCache{uType, rateType, PType, F, uNoUnitsType} <:
        OrdinaryDiffEqMutableCache
-    tmp::uType
     k::rateType
     fsalfirst::rateType
     P::PType
@@ -317,8 +315,7 @@ function alg_cache(alg::MPE, u, rate_prototype, ::Type{uEltypeNoUnits},
         linsolve = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
                         assumptions = LinearSolve.OperatorAssumptions(true))
 
-        MPEConservativeCache(tmp,
-                             zero(rate_prototype), # k
+        MPEConservativeCache(zero(rate_prototype), # k
                              zero(rate_prototype), # fsalfirst
                              P,
                              linsolve_tmp, linsolve, weight)
@@ -329,8 +326,7 @@ function alg_cache(alg::MPE, u, rate_prototype, ::Type{uEltypeNoUnits},
         linsolve = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
                         assumptions = LinearSolve.OperatorAssumptions(true))
 
-        MPECache(tmp,
-                 zero(rate_prototype), # k
+        MPECache(zero(rate_prototype), # k
                  zero(rate_prototype), # fsalfirst
                  P,
                  zero(u), #D


### PR DESCRIPTION
Don't know if we actually want to merge this. Just wanted to see which fields in the caches are necessary.

Removed unnecessary fields from caches. Removed `dolinsolve` for `MPE`.
