### PR TITLE
Implementation of MPRK22 and MPRK43 for nonconservative PDS (includes cleaning up the caches)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PositiveIntegrators"
 uuid = "d1b20bf0-b083-4985-a874-dc5121669aa5"
 authors = ["Stefan Kopecz, Hendrik Ranocha, and contributors"]
-version = "0.1.13"
+version = "0.1.14"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -1111,7 +1111,7 @@ function alg_cache(alg::Union{MPRK43I, MPRK43II}, u, rate_prototype, ::Type{uElt
 
     if f isa ConservativePDSFunction
         # The right hand side of the linear system is always uprev. But using
-        # tmp instead of uprev for the rhs we allows'alias_b=true'. uprev must
+        # tmp instead of uprev for the rhs we allow `alias_b=true`. uprev must
         # not be altered, since it is needed to compute the adaptive time step
         # size. 
         linprob = LinearProblem(P3, _vec(tmp))

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -408,7 +408,7 @@ Torlo, Öffner and Ranocha (2022).
 
 The scheme was introduced by Kopecz and Meister for conservative production-destruction systems. 
 For nonconservative production–destruction systems we use the straight forward extension
-analogous to `MPE`.
+analogous to [`MPE`](@ref).
 
 This modified Patankar-Runge-Kutta method requires the special structure of a
 [`PDSProblem`](@ref) or a [`ConservativePDSProblem`](@ref).

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -166,7 +166,7 @@ first-order accurate, unconditionally positivity-preserving, and
 linearly implicit.
 
 The scheme was introduced by Burchard et al for conservative production-destruction systems. 
-For nonconservative production–destruction system we use the straight forward extension
+For nonconservative production–destruction systems we use the straight forward extension
 
 ``u_i^{n+1} = u_i^n + Δt \\sum_{j, j≠i} \\biggl(p_{ij}^n \\frac{u_j^{n+1}}{u_j^n}-d_{ij}^n \\frac{u_i^{n+1}}{u_i^n}\\biggr) + {\\Delta}t p_{ii}^n - Δt d_{ii}^n\\frac{u_i^{n+1}}{u_i^n}``.
 
@@ -224,23 +224,6 @@ function alg_cache(alg::MPE, u, rate_prototype, ::Type{uEltypeNoUnits},
 end
 
 function initialize!(integrator, cache::MPEConstantCache)
-    integrator.kshortsize = 1
-    integrator.k = typeof(integrator.k)(undef, integrator.kshortsize)
-
-    # Avoid undefined entries if k is an array of arrays
-    integrator.fsalfirst = zero(integrator.u)
-    integrator.fsallast = integrator.fsalfirst
-    integrator.k[1] = integrator.fsallast
-
-    # TODO: Do we need to set fsalfirst here? The other non-FSAL caches
-    #       in OrdinaryDiffEq.jl use something like
-    #         integrator.fsalfirst = integrator.f(integrator.uprev, integrator,
-    #                                             integrator.t) # Pre-start fsal
-    #         integrator.stats.nf += 1
-    #         integrator.fsallast = zero(integrator.fsalfirst)
-    #         integrator.k[1] = integrator.fsalfirst
-    #       Do we need something similar here to get a cache for k values
-    #       with the correct units?
 end
 
 function perform_step!(integrator, cache::MPEConstantCache, repeat_step = false)
@@ -416,7 +399,7 @@ end
 """
     MPRK22(α; [linsolve = ...])
 
-The second-order modified Patankar-Runge-Kutta algorithm for (conservative)
+The second-order modified Patankar-Runge-Kutta algorithm for 
 production-destruction systems. This one-step, two-stage method is
 second-order accurate, unconditionally positivity-preserving, and linearly
 implicit. The parameter `α` is described by Kopecz and Meister (2018) and

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -773,7 +773,7 @@ see Kopecz and Meister (2018) for details.
 
 The scheme was introduced by Kopecz and Meister for conservative production-destruction systems. 
 For nonconservative production–destruction systems we use the straight forward extension
-analogous to `MPE`.
+analogous to [`MPE`](@ref).
 
 These modified Patankar-Runge-Kutta methods require the special structure of a
 [`PDSProblem`](@ref) or a [`ConservativePDSProblem`](@ref).

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -859,7 +859,7 @@ Further details are given in Kopecz and Meister (2018).
 
 The scheme was introduced by Kopecz and Meister for conservative production-destruction systems. 
 For nonconservative production–destruction systems we use the straight forward extension
-analogous to `MPE`.
+analogous to [`MPE`](@ref).
 
 These modified Patankar-Runge-Kutta methods require the special structure of a
 [`PDSProblem`](@ref) or a [`ConservativePDSProblem`](@ref).

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -1247,9 +1247,11 @@ function perform_step!(integrator, cache::MPRK43Cache, repeat_step = false)
     # Same as linres = P3 \ tmp
     linsolve.A = P3
     linres = solve!(linsolve)
+    integrator.stats.nsolve += 1
 
     σ .= linres
-    integrator.stats.nsolve += 1
+    # avoid division by zero due to zero Patankar weights
+    @.. broadcast=false σ=σ + small_constant
 
     f.p(P3, u, p, t + c3 * dt) # evaluate production terms
     f.d(D3, u, p, t + c3 * dt) # evaluate nonconservative destruction terms
@@ -1339,9 +1341,11 @@ function perform_step!(integrator, cache::MPRK43ConservativeCache, repeat_step =
     # Same as linres = P3 \ tmp
     linsolve.A = P3
     linres = solve!(linsolve)
+    integrator.stats.nsolve += 1
 
     σ .= linres
-    integrator.stats.nsolve += 1
+    # avoid division by zero due to zero Patankar weights
+    @.. broadcast=false σ=σ + small_constant
 
     f.p(P3, u, p, t + c3 * dt) # evaluate production terms
     @.. broadcast=false P3=b1 * P + b2 * P2 + b3 * P3

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -193,17 +193,6 @@ function MPE(; linsolve = LUFactorization())
     MPE(linsolve)
 end
 
-# TODO: Think about adding preconditioners to the MPE algorithm
-# This hack is currently required to make OrdinaryDiffEq.jl happy...
-function Base.getproperty(alg::MPE, f::Symbol)
-    # preconditioners
-    if f === :precs
-        return Returns((nothing, nothing))
-    else
-        return getfield(alg, f)
-    end
-end
-
 alg_order(::MPE) = 1
 isfsal(::MPE) = false
 
@@ -456,17 +445,6 @@ end
 
 function MPRK22(alpha; linsolve = LUFactorization())
     MPRK22{typeof(alpha), typeof(linsolve)}(alpha, linsolve)
-end
-
-# TODO: Think about adding preconditioners to the MPRK22 algorithm
-# This hack is currently required to make OrdinaryDiffEq.jl happy...
-function Base.getproperty(alg::MPRK22, f::Symbol)
-    # preconditioners
-    if f === :precs
-        return Returns((nothing, nothing))
-    else
-        return getfield(alg, f)
-    end
 end
 
 alg_order(::MPRK22) = 2
@@ -935,17 +913,6 @@ function get_constant_parameters(alg::MPRK43II)
         throw(ArgumentError("MPRK43II requires nonnegative RK coefficients."))
     end
     return a21, a31, a32, b1, b2, b3, c2, c3, beta1, beta2, q1, q2
-end
-
-# TODO: Think about adding preconditioners to the algorithm
-# This hack is currently required to make OrdinaryDiffEq.jl happy...
-function Base.getproperty(alg::Union{MPRK43I, MPRK43II}, f::Symbol)
-    # preconditioners
-    if f === :precs
-        return Returns((nothing, nothing))
-    else
-        return getfield(alg, f)
-    end
 end
 
 struct MPRK43ConstantCache{T} <: OrdinaryDiffEqConstantCache

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -851,7 +851,7 @@ end
 A family of third-order modified Patankar-Runge-Kutta schemes for (conservative)
 production-destruction systems, which is based on the one-parameter family of third order explicit Runge--Kutta schemes with 
 non-negative Runge--Kutta coefficients.
-Each member of this family is a one-step method with four-stages which is
+Each member of this family is a one-step method with four stages which is
 third-order accurate, unconditionally positivity-preserving, conservative and linearly
 implicit. In this implementation the stage-values are conservative as well. The parameter `γ` must satisfy
 `3/8 ≤ γ ≤ 3/4`. 

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -602,7 +602,7 @@ function alg_cache(alg::MPRK22, u, rate_prototype, ::Type{uEltypeNoUnits},
 
     if f isa ConservativePDSFunction
         # The right hand side of the linear system is always uprev. But using
-        # tmp instead of uprev for the rhs we allows'alias_b=true'. uprev must
+        # tmp instead of uprev for the rhs we allow `alias_b=true`. uprev must
         # not be altered, since it is needed to compute the adaptive time step
         # size. 
         linprob = LinearProblem(P2, _vec(tmp))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -592,11 +592,9 @@ const prob_pds_linmod_nonconservative_inplace = PDSProblem(linmodP!, linmodD!, [
             dt = 0.25
 
             @testset "$alg" for alg in (MPE(),
-                                        MPRK22(0.5), MPRK22(1.0)
-                                        #TODO: Add MPRK43 (not implemented yet)
-                                        #MPRK43I(1.0, 0.5), MPRK43I(0.5, 0.75),
-                                        #MPRK43II(2.0 / 3.0), MPRK43II(0.5)
-                                        )
+                                        MPRK22(0.5), MPRK22(1.0),
+                                        MPRK43I(1.0, 0.5), MPRK43I(0.5, 0.75),
+                                        MPRK43II(2.0 / 3.0), MPRK43II(0.5))
                 for (prod!, dest!) in zip((prod_1!, prod_2!, prod_3!),
                                           (dest_1!, dest_2!, dest_3!))
                     prod = (u, p, t) -> begin
@@ -721,11 +719,23 @@ const prob_pds_linmod_nonconservative_inplace = PDSProblem(linmodP!, linmodD!, [
         # Here we check the convergence order of pth-order schemes for which
         # no interpolation of order p is available
         @testset "Convergence tests (nonconservative)" begin
-            #TODO: Check convergence of 3rd order MPRK schemes for nonconservative PDS (not yet implemented)
+            dts = 0.5 .^ (6:11)
+            problems = (prob_pds_linmod_nonconservative,
+                        prob_pds_linmod_nonconservative_inplace)
+            for alg in [
+                    MPRK43I(1.0, 0.5),
+                    MPRK43I(0.5, 0.75),
+                    MPRK43II(0.5),
+                    MPRK43II(2.0 / 3.0),
+                ], prob in problems
+                eoc = experimental_order_of_convergence(prob, alg, dts)
+                @test isapprox(eoc, PositiveIntegrators.alg_order(alg); atol = 0.2)
+            end
         end
 
         @testset "Interpolation tests (conservative)" begin
-            algs = (MPE(), MPRK22(0.5), MPRK22(1.0), MPRK22(2.0))
+            algs = (MPE(), MPRK22(0.5), MPRK22(1.0), MPRK22(2.0), MPRK43I(1.0, 0.5),
+                    MPRK43I(0.5, 0.75), MPRK43II(0.5), MPRK43II(2.0 / 3.0))
             dt = 0.5^6
             problems = (prob_pds_linmod, prob_pds_linmod_array,
                         prob_pds_linmod_mvector, prob_pds_linmod_inplace)
@@ -740,7 +750,8 @@ const prob_pds_linmod_nonconservative_inplace = PDSProblem(linmodP!, linmodD!, [
         end
 
         @testset "Interpolation tests (nonconservative)" begin
-            algs = (MPE(), MPRK22(0.5), MPRK22(1.0), MPRK22(2.0))
+            algs = (MPE(), MPRK22(0.5), MPRK22(1.0), MPRK22(2.0), MPRK43I(1.0, 0.5),
+                    MPRK43I(0.5, 0.75), MPRK43II(0.5), MPRK43II(2.0 / 3.0))
             dt = 0.5^6
             problems = (prob_pds_linmod_nonconservative,
                         prob_pds_linmod_nonconservative_inplace)
@@ -833,13 +844,9 @@ const prob_pds_linmod_nonconservative_inplace = PDSProblem(linmodP!, linmodD!, [
             prob_oop = ConservativePDSProblem(prod, u0, tspan, p)
             prob_oop_2 = PDSProblem(prod, dest, u0, tspan, p)
 
-            #=
-            TODO: Add MPRK43 schemes
             algs = (MPE(), MPRK22(0.5), MPRK22(1.0), MPRK22(2.0),
-            MPRK43I(1.0, 0.5),MPRK43I(0.5, 0.75),MPRK43II(0.5),
-            MPRK43II(2.0 / 3.0))
-            =#
-            algs = (MPE(), MPRK22(0.5), MPRK22(1.0), MPRK22(2.0))
+                    MPRK43I(1.0, 0.5), MPRK43I(0.5, 0.75), MPRK43II(0.5),
+                    MPRK43II(2.0 / 3.0))
 
             dt = 1e-3
             for alg in algs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -799,13 +799,13 @@ const prob_pds_linmod_nonconservative_inplace = PDSProblem(linmodP!, linmodD!, [
 
             for alg in algs
                 sol = solve(prob_ip, alg; dt = dt, adaptive = false)
-                @test !any(isnan.(sol.u[end]))
+                @test !any(isnan, sol.u[end])
                 sol = solve(prob_ip_2, alg; dt = dt, adaptive = false)
-                @test !any(isnan.(sol.u[end]))
+                @test !any(isnan, sol.u[end])
                 sol = solve(prob_oop, alg; dt = dt, adaptive = false)
-                @test !any(isnan.(sol.u[end]))
+                @test !any(isnan, sol.u[end])
                 sol = solve(prob_oop_2, alg; dt = dt, adaptive = false)
-                @test !any(isnan.(sol.u[end]))
+                @test !any(isnan, sol.u[end])
             end
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -848,13 +848,13 @@ const prob_pds_linmod_nonconservative_inplace = PDSProblem(linmodP!, linmodD!, [
             dt = 1e-3
             for alg in algs
                 sol1 = solve(prob_ip, alg; dt = dt, adaptive = false)
-                @test !any(isnan.(sol1.u[end]))
+                @test !any(isnan, sol1.u[end])
                 sol2 = solve(prob_ip_2, alg; dt = dt, adaptive = false)
-                @test !any(isnan.(sol2.u[end]))
+                @test !any(isnan, sol2.u[end])
                 sol3 = solve(prob_oop, alg; dt = dt, adaptive = false)
-                @test !any(isnan.(sol3.u[end]))
+                @test !any(isnan, sol3.u[end])
                 sol4 = solve(prob_oop_2, alg; dt = dt, adaptive = false)
-                @test !any(isnan.(sol4.u[end]))
+                @test !any(isnan, sol4.u[end])
                 @test sol1.u ≈ sol2.u ≈ sol3.u ≈ sol4.u
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -722,12 +722,9 @@ const prob_pds_linmod_nonconservative_inplace = PDSProblem(linmodP!, linmodD!, [
             dts = 0.5 .^ (6:11)
             problems = (prob_pds_linmod_nonconservative,
                         prob_pds_linmod_nonconservative_inplace)
-            for alg in [
-                    MPRK43I(1.0, 0.5),
-                    MPRK43I(0.5, 0.75),
-                    MPRK43II(0.5),
-                    MPRK43II(2.0 / 3.0),
-                ], prob in problems
+            algs = (MPRK43I(1.0, 0.5), MPRK43I(0.5, 0.75),
+                    MPRK43II(0.5), MPRK43II(2.0 / 3.0))
+            for alg in algs, prob in problems
                 eoc = experimental_order_of_convergence(prob, alg, dts)
                 @test isapprox(eoc, PositiveIntegrators.alg_order(alg); atol = 0.2)
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ using StaticArrays: MVector
 using OrdinaryDiffEq
 using PositiveIntegrators
 
-using LinearSolve: RFLUFactorization, LUFactorization
+using LinearSolve: RFLUFactorization, LUFactorization, KrylovJL_GMRES
 
 using Aqua: Aqua
 
@@ -431,8 +431,12 @@ const prob_pds_linmod_nonconservative_inplace = PDSProblem(linmodP!, linmodD!, [
                 sol2_2 = solve(prob_ip_2, alg(linsolve = RFLUFactorization()); dt)
                 sol3 = solve(prob_ip, alg(linsolve = LUFactorization()); dt)
                 sol3_2 = solve(prob_ip_2, alg(linsolve = LUFactorization()); dt)
-                @test sol1.t ≈ sol2.t ≈ sol3.t ≈ sol1_2.t ≈ sol2_2.t ≈ sol3_2.t
-                @test sol1.u ≈ sol2.u ≈ sol3.u ≈ sol1_2.u ≈ sol2_2.u ≈ sol3_2.u
+                sol4 = solve(prob_ip, alg(linsolve = KrylovJL_GMRES()); dt)
+                sol4_2 = solve(prob_ip_2, alg(linsolve = KrylovJL_GMRES()); dt)
+                @test sol1.t ≈ sol2.t ≈ sol3.t ≈ sol4.t ≈ sol1_2.t ≈ sol2_2.t ≈ sol3_2.t ≈
+                      sol4_2.t
+                @test sol1.u ≈ sol2.u ≈ sol3.u ≈ sol4.u ≈ sol1_2.u ≈ sol2_2.u ≈ sol3_2.u ≈
+                      sol4_2.u
             end
         end
 
@@ -591,55 +595,62 @@ const prob_pds_linmod_nonconservative_inplace = PDSProblem(linmodP!, linmodD!, [
             tspan = (0.0, 1.0)
             dt = 0.25
 
-            for (prod!, dest!) in zip((prod_1!, prod_2!, prod_3!),
-                                      (dest_1!, dest_2!, dest_3!))
-                prod = (u, p, t) -> begin
-                    P = similar(u, (length(u), length(u)))
-                    prod!(P, u, p, t)
-                    return P
+            @testset "$alg" for alg in (MPE(),
+                                        MPRK22(0.5), MPRK22(1.0)
+                                        #TODO: Add MPRK43 (not implemented yet)
+                                        #MPRK43I(1.0, 0.5), MPRK43I(0.5, 0.75),
+                                        #MPRK43II(2.0 / 3.0), MPRK43II(0.5)
+                                        )
+                for (prod!, dest!) in zip((prod_1!, prod_2!, prod_3!),
+                                          (dest_1!, dest_2!, dest_3!))
+                    prod = (u, p, t) -> begin
+                        P = similar(u, (length(u), length(u)))
+                        prod!(P, u, p, t)
+                        return P
+                    end
+                    dest = (u, p, t) -> begin
+                        D = similar(u)
+                        dest!(D, u, p, t)
+                        return D
+                    end
+                    prob_tridiagonal_ip = PDSProblem(prod!, dest!, u0, tspan;
+                                                     p_prototype = P_tridiagonal)
+                    prob_tridiagonal_op = PDSProblem(prod, dest, u0, tspan;
+                                                     p_prototype = P_tridiagonal)
+                    prob_dense_ip = PDSProblem(prod!, dest!, u0, tspan;
+                                               p_prototype = P_dense)
+                    prob_dense_op = PDSProblem(prod, dest, u0, tspan;
+                                               p_prototype = P_dense)
+                    prob_sparse_ip = PDSProblem(prod!, dest!, u0, tspan;
+                                                p_prototype = P_sparse)
+                    prob_sparse_op = PDSProblem(prod, dest, u0, tspan;
+                                                p_prototype = P_sparse)
+
+                    sol_tridiagonal_ip = solve(prob_tridiagonal_ip, alg;
+                                               dt, adaptive = false)
+                    sol_tridiagonal_op = solve(prob_tridiagonal_op, alg;
+                                               dt, adaptive = false)
+                    sol_dense_ip = solve(prob_dense_ip, alg;
+                                         dt, adaptive = false)
+                    sol_dense_op = solve(prob_dense_op, alg;
+                                         dt, adaptive = false)
+                    sol_sparse_ip = solve(prob_sparse_ip, alg;
+                                          dt, adaptive = false)
+                    sol_sparse_op = solve(prob_sparse_op, alg;
+                                          dt, adaptive = false)
+
+                    @test sol_tridiagonal_ip.t ≈ sol_tridiagonal_op.t
+                    @test sol_dense_ip.t ≈ sol_dense_op.t
+                    @test sol_sparse_ip.t ≈ sol_sparse_op.t
+                    @test sol_tridiagonal_ip.t ≈ sol_dense_ip.t
+                    @test sol_tridiagonal_ip.t ≈ sol_sparse_ip.t
+
+                    @test sol_tridiagonal_ip.u ≈ sol_tridiagonal_op.u
+                    @test sol_dense_ip.u ≈ sol_dense_op.u
+                    @test sol_sparse_ip.u ≈ sol_sparse_op.u
+                    @test sol_tridiagonal_ip.u ≈ sol_dense_ip.u
+                    @test sol_tridiagonal_ip.u ≈ sol_sparse_ip.u
                 end
-                dest = (u, p, t) -> begin
-                    D = similar(u)
-                    dest!(D, u, p, t)
-                    return D
-                end
-                prob_tridiagonal_ip = PDSProblem(prod!, dest!, u0, tspan;
-                                                 p_prototype = P_tridiagonal)
-                prob_tridiagonal_op = PDSProblem(prod, dest, u0, tspan;
-                                                 p_prototype = P_tridiagonal)
-                prob_dense_ip = PDSProblem(prod!, dest!, u0, tspan;
-                                           p_prototype = P_dense)
-                prob_dense_op = PDSProblem(prod, dest, u0, tspan;
-                                           p_prototype = P_dense)
-                prob_sparse_ip = PDSProblem(prod!, dest!, u0, tspan;
-                                            p_prototype = P_sparse)
-                prob_sparse_op = PDSProblem(prod, dest, u0, tspan;
-                                            p_prototype = P_sparse)
-
-                sol_tridiagonal_ip = solve(prob_tridiagonal_ip, MPE();
-                                           dt, adaptive = false)
-                sol_tridiagonal_op = solve(prob_tridiagonal_op, MPE();
-                                           dt, adaptive = false)
-                sol_dense_ip = solve(prob_dense_ip, MPE();
-                                     dt, adaptive = false)
-                sol_dense_op = solve(prob_dense_op, MPE();
-                                     dt, adaptive = false)
-                sol_sparse_ip = solve(prob_sparse_ip, MPE();
-                                      dt, adaptive = false)
-                sol_sparse_op = solve(prob_sparse_op, MPE();
-                                      dt, adaptive = false)
-
-                @test sol_tridiagonal_ip.t ≈ sol_tridiagonal_op.t
-                @test sol_dense_ip.t ≈ sol_dense_op.t
-                @test sol_sparse_ip.t ≈ sol_sparse_op.t
-                @test sol_tridiagonal_ip.t ≈ sol_dense_ip.t
-                @test sol_tridiagonal_ip.t ≈ sol_sparse_ip.t
-
-                @test sol_tridiagonal_ip.u ≈ sol_tridiagonal_op.u
-                @test sol_dense_ip.u ≈ sol_dense_op.u
-                @test sol_sparse_ip.u ≈ sol_sparse_op.u
-                @test sol_tridiagonal_ip.u ≈ sol_dense_ip.u
-                @test sol_tridiagonal_ip.u ≈ sol_sparse_ip.u
             end
         end
 
@@ -671,25 +682,26 @@ const prob_pds_linmod_nonconservative_inplace = PDSProblem(linmodP!, linmodD!, [
 
         # Here we check the convergence order of pth-order schemes for which
         # also an interpolation of order p is available
-        #TODO: Add MPRK22 (not yet implemented)
         @testset "Convergence tests (nonconservative)" begin
-            alg = MPE()
+            algs = (MPE(), MPRK22(0.5), MPRK22(1.0), MPRK22(2.0))
             dts = 0.5 .^ (6:11)
             problems = (prob_pds_linmod_nonconservative,
                         prob_pds_linmod_nonconservative_inplace)
-            for prob in problems
-                eoc = experimental_order_of_convergence(prob, alg, dts)
-                @test isapprox(eoc, PositiveIntegrators.alg_order(alg); atol = 0.2)
+            for alg in algs
+                for prob in problems
+                    eoc = experimental_order_of_convergence(prob, alg, dts)
+                    @test isapprox(eoc, PositiveIntegrators.alg_order(alg); atol = 0.2)
 
-                test_times = [
-                    0.123456789, 1 / pi, exp(-1),
-                    1.23456789, 1 + 1 / pi, 1 + exp(-1),
-                ]
-                eoc = experimental_order_of_convergence(prob, alg, dts, test_times)
-                @test isapprox(eoc, PositiveIntegrators.alg_order(alg); atol = 0.2)
-                eoc = experimental_order_of_convergence(prob, alg, dts, test_times;
-                                                        only_first_index = true)
-                @test isapprox(eoc, PositiveIntegrators.alg_order(alg); atol = 0.2)
+                    test_times = [
+                        0.123456789, 1 / pi, exp(-1),
+                        1.23456789, 1 + 1 / pi, 1 + exp(-1),
+                    ]
+                    eoc = experimental_order_of_convergence(prob, alg, dts, test_times)
+                    @test isapprox(eoc, PositiveIntegrators.alg_order(alg); atol = 0.2)
+                    eoc = experimental_order_of_convergence(prob, alg, dts, test_times;
+                                                            only_first_index = true)
+                    @test isapprox(eoc, PositiveIntegrators.alg_order(alg); atol = 0.2)
+                end
             end
         end
 
@@ -747,6 +759,110 @@ const prob_pds_linmod_nonconservative_inplace = PDSProblem(linmodP!, linmodD!, [
         end
     end
 
+    # Check that the schemes accept zero initial values
+    @testset "Zero initial values" begin
+        # Do a single step and check that no NaNs occur
+        u0 = [1.0, 0.0]
+        dt = 1.0
+        tspan = (0.0, dt)
+        p = 1000.0
+        function prod!(P, u, p, t)
+            λ = p
+            fill!(P, zero(eltype(P)))
+            P[2, 1] = λ * u[1]
+        end
+        function dest!(D, u, p, t)
+            fill!(D, zero(eltype(D)))
+        end
+        function prod(u, p, t)
+            P = similar(u, (length(u), length(u)))
+            prod!(P, u, p, t)
+            return P
+        end
+        function dest(u, p, t)
+            d = similar(u)
+            dest!(d, u, p, t)
+            return d
+        end
+
+        prob_ip = ConservativePDSProblem(prod!, u0, tspan, p)
+        prob_ip_2 = PDSProblem(prod!, dest!, u0, tspan, p)
+        prob_oop = ConservativePDSProblem(prod, u0, tspan, p)
+        prob_oop_2 = PDSProblem(prod, dest, u0, tspan, p)
+
+        algs = (MPE(), MPRK22(0.5), MPRK22(1.0), MPRK22(2.0),
+                MPRK43I(1.0, 0.5), MPRK43I(0.5, 0.75), MPRK43II(0.5),
+                MPRK43II(2.0 / 3.0))
+
+        for alg in algs
+            sol = solve(prob_ip, alg; dt = dt, adaptive = false)
+            @test !any(isnan.(sol.u[end]))
+            sol = solve(prob_ip_2, alg; dt = dt, adaptive = false)
+            @test !any(isnan.(sol.u[end]))
+            sol = solve(prob_oop, alg; dt = dt, adaptive = false)
+            @test !any(isnan.(sol.u[end]))
+            sol = solve(prob_oop_2, alg; dt = dt, adaptive = false)
+            @test !any(isnan.(sol.u[end]))
+        end
+    end
+
+    # Check that approximations, and thus the Patankar weights,
+    # remain positive to avoid division by zero.
+    @testset "Positvity check" begin
+        # For this problem u[1] decreases montonically to 0 very fast.
+        # We perform 10^5 steps and check that u[end] does not contain any NaNs
+        u0 = [0.9, 0.1]
+        tspan = (0.0, 100.0)
+        p = 1000.0
+        function prod!(P, u, p, t)
+            λ = p
+            fill!(P, zero(eltype(P)))
+            P[2, 1] = λ * u[1]
+        end
+        function dest!(D, u, p, t)
+            fill!(D, zero(eltype(D)))
+        end
+        function prod(u, p, t)
+            P = similar(u, (length(u), length(u)))
+            prod!(P, u, p, t)
+            return P
+        end
+        function dest(u, p, t)
+            d = similar(u)
+            dest!(d, u, p, t)
+            return d
+        end
+
+        prob_ip = ConservativePDSProblem(prod!, u0, tspan, p)
+        prob_ip_2 = PDSProblem(prod!, dest!, u0, tspan, p)
+        prob_oop = ConservativePDSProblem(prod, u0, tspan, p)
+        prob_oop_2 = PDSProblem(prod, dest, u0, tspan, p)
+
+        #=
+        TODO: Add MPRK43 schemes
+        algs = (MPE(), MPRK22(0.5), MPRK22(1.0), MPRK22(2.0),
+        MPRK43I(1.0, 0.5),MPRK43I(0.5, 0.75),MPRK43II(0.5),
+        MPRK43II(2.0 / 3.0))
+        =#
+        algs = (MPE(), MPRK22(0.5), MPRK22(1.0), MPRK22(2.0))
+
+        dt = 1e-3
+        for alg in algs
+            sol1 = solve(prob_ip, alg; dt = dt, adaptive = false)
+            @test !any(isnan.(sol1.u[end]))
+            sol2 = solve(prob_ip_2, alg; dt = dt, adaptive = false)
+            @test !any(isnan.(sol2.u[end]))
+            sol3 = solve(prob_oop, alg; dt = dt, adaptive = false)
+            @test !any(isnan.(sol3.u[end]))
+            sol4 = solve(prob_oop_2, alg; dt = dt, adaptive = false)
+            @test !any(isnan.(sol4.u[end]))
+            @test sol1.u ≈ sol2.u ≈ sol3.u ≈ sol4.u
+        end
+    end
+
+    #TODO Add test with zero initial conditions (in-place and out-of-place)
+
+    #=
     # TODO: Do we want to keep the examples and test them or do we want
     #       to switch to real docs/tutorials instead?
     @testset "Examples" begin
@@ -770,4 +886,5 @@ const prob_pds_linmod_nonconservative_inplace = PDSProblem(linmodP!, linmodD!, [
             end
         end
     end
+    =#
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -418,6 +418,7 @@ const prob_pds_linmod_nonconservative_inplace = PDSProblem(linmodP!, linmodD!, [
                     (; kwargs...) -> MPRK43I(0.5, 0.75; kwargs...),
                     (; kwargs...) -> MPRK43II(0.5; kwargs...),
                     (; kwargs...) -> MPRK43II(2.0 / 3.0; kwargs...))
+
             for alg in algs
                 # Check different linear solvers
                 dt = 0.25
@@ -523,7 +524,6 @@ const prob_pds_linmod_nonconservative_inplace = PDSProblem(linmodP!, linmodD!, [
 
         # Here we check that in-place and out-of-place implementations
         # deliver the same results
-        #TODO: Add 2nd and 3rd order schemes (not yet implemented)
         @testset "Different matrix types (nonconservative)" begin
             prod_1! = (P, u, p, t) -> begin
                 fill!(P, zero(eltype(P)))
@@ -856,7 +856,6 @@ const prob_pds_linmod_nonconservative_inplace = PDSProblem(linmodP!, linmodD!, [
         end
     end
 
-    #=
     # TODO: Do we want to keep the examples and test them or do we want
     #       to switch to real docs/tutorials instead?
     @testset "Examples" begin
@@ -880,5 +879,4 @@ const prob_pds_linmod_nonconservative_inplace = PDSProblem(linmodP!, linmodD!, [
             end
         end
     end
-    =#
 end;


### PR DESCRIPTION
- Removed unnecessary code in `initialize! `for out-of-place `MPE`.
- Added tests to check that zero initial values don't cause division by zero.
- Added tests to check that division by zero is avoided for problems with solutions that tend monotonically to zero.
- Implemented `MPRK22` and `MPRK43` for nonconservative PDS.
- Removed `dolinsolve` in `MPRK22` and `MPRK43`.
- Cleaned caches of `MPRK22` and `MPRK43`.
- Added tests for `MPRK22` and `MPRK43` solving nenconservative PDS.
- Removed hacks for preconditioners.