### PR TITLE
remove PositiveIntegrators from docs/Project.toml

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,7 +3,6 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-PositiveIntegrators = "d1b20bf0-b083-4985-a874-dc5121669aa5"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]


### PR DESCRIPTION
It should work without this and this simplifies stuff since we do not need to keep the compat entry in docs/Project.toml up to date.

Closes #100 