### PR TITLE
Order API reference

### DIFF
--- a/docs/src/api_reference.md
+++ b/docs/src/api_reference.md
@@ -4,6 +4,34 @@
 CurrentModule = PositiveIntegrators
 ```
 
-```@autodocs
-Modules = [PositiveIntegrators]
+## Problem types
+
+```@docs
+ConservativePDSProblem
+PDSProblem
+```
+
+## Example problems
+
+```@docs
+prob_pds_bertolazzi
+prob_pds_brusselator
+prob_pds_linmod
+prob_pds_linmod_inplace
+prob_pds_nonlinmod
+prob_pds_npzd
+prob_pds_robertson
+prob_pds_sir
+prob_pds_stratreac
+```
+
+## Algorithms
+
+```@docs
+MPE
+MPRK22
+SSPMPRK22
+MPRK43I
+MPRK43II
+SSPMPRK43
 ```


### PR DESCRIPTION
The current version of the API reference docs is just ordered alphabetically by name of things, see https://skopecz.github.io/PositiveIntegrators.jl/v0.1/api_reference/

In this PR, I ordered the API references manually, sorting them by the type of stuff: general problem types, pre-made problems, and algorithms. I think this makes it easier to search the API reference