### PR TITLE
add possibility to call a direct implementation of the ODE RHS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PositiveIntegrators"
 uuid = "d1b20bf0-b083-4985-a874-dc5121669aa5"
 authors = ["Stefan Kopecz, Hendrik Ranocha, and contributors"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"

--- a/src/proddest.jl
+++ b/src/proddest.jl
@@ -125,7 +125,6 @@ function PDSFunction{iip, FullSpecialize}(P, D;
     if std_rhs === nothing
         std_rhs = PDSStdRHS(P, D, p_prototype, d_prototype)
     end
-    @info "constructor" std_rhs
     PDSFunction{iip, FullSpecialize, typeof(P), typeof(D), typeof(p_prototype),
                 typeof(d_prototype),
                 typeof(std_rhs), typeof(analytic)}(P, D, p_prototype, d_prototype, std_rhs, analytic)
@@ -150,8 +149,10 @@ end
 
 # Evaluation of a PDSStdRHS (out-of-place)
 function (PD::PDSStdRHS)(u, p, t)
-    diag(PD.p(u, p, t)) + vec(sum(PD.p(u, p, t), dims = 2)) -
-    vec(sum(PD.p(u, p, t), dims = 1)) - vec(PD.d(u, p, t))
+    P = PD.p(u, p, t)
+    D = PD.d(u, p, t)
+    diag(P) + vec(sum(P, dims = 2)) -
+    vec(sum(P, dims = 1)) - vec(D)
 end
 
 # Evaluation of a PDSStdRHS (in-place)

--- a/src/proddest.jl
+++ b/src/proddest.jl
@@ -3,13 +3,13 @@ abstract type AbstractPDSProblem end
 
 """
     PDSProblem(P, D, u0, tspan, p = NullParameters();
-                       p_prototype = nothing,
-                       analytic = nothing)
+               p_prototype = nothing,
+               analytic = nothing)
 
 A structure describing a system of ordinary differential equations in form of a production-destruction system (PDS).
-`P` denotes the production matrix.
-The diagonal of `P` contains production terms without destruction counterparts.
-`D` is the vector of destruction terms without production counterparts.
+`P` denotes the function defining the production matrix ``P``.
+The diagonal of ``P`` contains production terms without destruction counterparts.
+`D` is the function defining the vector of destruction terms ``D`` without production counterparts.
 `u0` is the vector of initial conditions and `tspan` the time span
 `(t_initial, t_final)` of the problem. The optional argument `p` can be used
 to pass additional parameters to the functions `P` and `D`.
@@ -20,10 +20,10 @@ The functions `P` and `D` can be used either in the out-of-place form with signa
 ### Keyword arguments: ###
 
 - `p_prototype`: If `P` is given in in-place form, `p_prototype` or copies thereof are used to store evaluations of `P`.
-    If `p_prototype` is not specified explicitly and `P` is in-place, then `p_prototype` will be internally
+  If `p_prototype` is not specified explicitly and `P` is in-place, then `p_prototype` will be internally
   set to `zeros(eltype(u0), (length(u0), length(u0)))`.
 - `analytic`: The analytic solution of a PDS must be given in the form `f(u0,p,t)`.
-    Specifying the analytic solution can be useful for plotting and convergence tests.
+  Specifying the analytic solution can be useful for plotting and convergence tests.
 
 ## References
 
@@ -88,7 +88,7 @@ function PDSProblem{iip}(P, D, u0, tspan, p = NullParameters();
     if isnothing(p_prototype) && iip
         p_prototype = zeros(eltype(u0), (length(u0), length(u0)))
     end
-    # If a PDSFunction is to be evaluated and D is in-place, then d_prototype is used to store 
+    # If a PDSFunction is to be evaluated and D is in-place, then d_prototype is used to store
     # evaluations of D.
     d_prototype = similar(u0)
 
@@ -160,10 +160,11 @@ end
                            analytic = nothing)
 
 A structure describing a conservative system of ordinary differential equation in form of a production-destruction system (PDS).
-`P` denotes the production matrix.
+`P` denotes the function defining the production matrix ``P``.
+The diagonal of ``P`` contains production terms without destruction counterparts.
 `u0` is the vector of initial conditions and `tspan` the time span
 `(t_initial, t_final)` of the problem. The optional argument `p` can be used
-to pass additional parameters to the function P.
+to pass additional parameters to the function `P`.
 
 The function `P` can be given either in the out-of-place form with signature
 `production_terms = P(u, p, t)` or the in-place form `P(production_terms, u, p, t)`.
@@ -171,10 +172,10 @@ The function `P` can be given either in the out-of-place form with signature
 ### Keyword arguments: ###
 
 - `p_prototype`: If `P` is given in in-place form, `p_prototype` or copies thereof are used to store evaluations of `P`.
-    If `p_prototype` is not specified explicitly and `P` is in-place, then `p_prototype` will be internally
+  If `p_prototype` is not specified explicitly and `P` is in-place, then `p_prototype` will be internally
   set to `zeros(eltype(u0), (length(u0), length(u0)))`.
 - `analytic`: The analytic solution of a PDS must be given in the form `f(u0,p,t)`.
-    Specifying the analytic solution can be useful for plotting and convergence tests.
+  Specifying the analytic solution can be useful for plotting and convergence tests.
 
 ## References
 


### PR DESCRIPTION
Closes #56

I think this will be useful for performance benchmarks since it provides a fair possibility for default methods from OrdinaryDiffEq.jl (avoiding the overhead of computing production/destruction terms and summing them up to get the standard ODE RHS value).