### PR TITLE
Implementation of `get_fsalfirstlast` for MPRK schemes

### DIFF
--- a/src/PositiveIntegrators.jl
+++ b/src/PositiveIntegrators.jl
@@ -35,7 +35,8 @@ import OrdinaryDiffEq: alg_order, isfsal,
                        calculate_residuals, calculate_residuals!,
                        alg_cache, get_tmp_cache,
                        initialize!, perform_step!,
-                       _ode_interpolant, _ode_interpolant!
+                       _ode_interpolant, _ode_interpolant!,
+                       get_fsalfirstlast
 
 # 2. Export functionality defining the public API
 export PDSFunction, PDSProblem

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -321,7 +321,10 @@ end
     integrator.u = u
 end
 
-struct MPECache{PType, uType, tabType, F} <: OrdinaryDiffEqMutableCache
+abstract type MPEMutableCache <: OrdinaryDiffEqMutableCache end
+get_fsalfirstlast(cache::MPEMutableCache, rate_prototype) = (cache.fsalfirst, cache.k)
+
+struct MPECache{PType, uType, tabType, F} <: MPEMutableCache
     P::PType
     D::uType
     σ::uType
@@ -330,7 +333,7 @@ struct MPECache{PType, uType, tabType, F} <: OrdinaryDiffEqMutableCache
     linsolve::F
 end
 
-struct MPEConservativeCache{PType, uType, tabType, F} <: OrdinaryDiffEqMutableCache
+struct MPEConservativeCache{PType, uType, tabType, F} <: MPEMutableCache
     P::PType
     σ::uType
     tab::tabType

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -217,6 +217,10 @@ end
     return nothing
 end
 
+# We use MPRKMutableCache as supertype for all MPRK scheme caches
+abstract type MPRKMutableCache <: OrdinaryDiffEqMutableCache end
+get_fsalfirstlast(cache::MPRKMutableCache, rate_prototype) = (nothing, nothing)
+
 ### MPE #####################################################################################
 """
     MPE([linsolve = ..., small_constant = ...])
@@ -321,10 +325,7 @@ end
     integrator.u = u
 end
 
-abstract type MPEMutableCache <: OrdinaryDiffEqMutableCache end
-get_fsalfirstlast(cache::MPEMutableCache, rate_prototype) = (cache.fsalfirst, cache.k)
-
-struct MPECache{PType, uType, tabType, F} <: MPEMutableCache
+struct MPECache{PType, uType, tabType, F} <: MPRKMutableCache
     P::PType
     D::uType
     σ::uType
@@ -333,7 +334,7 @@ struct MPECache{PType, uType, tabType, F} <: MPEMutableCache
     linsolve::F
 end
 
-struct MPEConservativeCache{PType, uType, tabType, F} <: MPEMutableCache
+struct MPEConservativeCache{PType, uType, tabType, F} <: MPRKMutableCache
     P::PType
     σ::uType
     tab::tabType
@@ -621,8 +622,7 @@ end
     integrator.u = u
 end
 
-struct MPRK22Cache{uType, PType, tabType, F} <:
-       OrdinaryDiffEqMutableCache
+struct MPRK22Cache{uType, PType, tabType, F} <: MPRKMutableCache
     tmp::uType
     P::PType
     P2::PType
@@ -633,8 +633,7 @@ struct MPRK22Cache{uType, PType, tabType, F} <:
     linsolve::F
 end
 
-struct MPRK22ConservativeCache{uType, PType, tabType, F} <:
-       OrdinaryDiffEqMutableCache
+struct MPRK22ConservativeCache{uType, PType, tabType, F} <: MPRKMutableCache
     tmp::uType
     P::PType
     P2::PType
@@ -1200,7 +1199,7 @@ end
     integrator.u = u
 end
 
-struct MPRK43Cache{uType, PType, tabType, F} <: OrdinaryDiffEqMutableCache
+struct MPRK43Cache{uType, PType, tabType, F} <: MPRKMutableCache
     tmp::uType
     tmp2::uType
     P::PType
@@ -1214,7 +1213,7 @@ struct MPRK43Cache{uType, PType, tabType, F} <: OrdinaryDiffEqMutableCache
     linsolve::F
 end
 
-struct MPRK43ConservativeCache{uType, PType, tabType, F} <: OrdinaryDiffEqMutableCache
+struct MPRK43ConservativeCache{uType, PType, tabType, F} <: MPRKMutableCache
     tmp::uType
     tmp2::uType
     P::PType

--- a/src/sspmprk.jl
+++ b/src/sspmprk.jl
@@ -201,8 +201,7 @@ end
     integrator.u = u
 end
 
-struct SSPMPRK22Cache{uType, PType, tabType, F} <:
-       OrdinaryDiffEqMutableCache
+struct SSPMPRK22Cache{uType, PType, tabType, F} <: MPRKMutableCache
     tmp::uType
     P::PType
     P2::PType
@@ -213,8 +212,7 @@ struct SSPMPRK22Cache{uType, PType, tabType, F} <:
     linsolve::F
 end
 
-struct SSPMPRK22ConservativeCache{uType, PType, tabType, F} <:
-       OrdinaryDiffEqMutableCache
+struct SSPMPRK22ConservativeCache{uType, PType, tabType, F} <: MPRKMutableCache
     tmp::uType
     P::PType
     P2::PType
@@ -709,7 +707,7 @@ end
     integrator.u = u
 end
 
-struct SSPMPRK43Cache{uType, PType, tabType, F} <: OrdinaryDiffEqMutableCache
+struct SSPMPRK43Cache{uType, PType, tabType, F} <: MPRKMutableCache
     tmp::uType
     tmp2::uType
     P::PType
@@ -724,7 +722,7 @@ struct SSPMPRK43Cache{uType, PType, tabType, F} <: OrdinaryDiffEqMutableCache
     linsolve::F
 end
 
-struct SSPMPRK43ConservativeCache{uType, PType, tabType, F} <: OrdinaryDiffEqMutableCache
+struct SSPMPRK43ConservativeCache{uType, PType, tabType, F} <: MPRKMutableCache
     tmp::uType
     tmp2::uType
     P::PType


### PR DESCRIPTION
Due to a change in OrdinaryDiffEq in-place problems cannot be solved currently. 
```julia
solve(prob_pds_linmod_inplace, MPE(); dt=0.1)

ERROR: MethodError: no method matching get_fsalfirstlast(::MPEConservativeCache{…}, ::Vector{…})
```

