### PR TITLE
Consolidate in-place implementations for ConservativePDSProblems and PDSProblems

### DIFF
--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -42,11 +42,11 @@ end
 
 #######################################################################################
 # interpolation specializations
-const MPRKCaches = Union{MPEConstantCache, MPECache, MPEConservativeCache,
+const MPRKCaches = Union{MPEConstantCache, MPECache,
                          MPRK22ConstantCache, MPRK22Cache,
-                         MPRK43ConstantCache, MPRK43Cache, MPRK43ConservativeCache,
-                         SSPMPRK22ConstantCache, SSPMPRK22Cache, SSPMPRK22ConservativeCache,
-                         SSPMPRK43ConstantCache, SSPMPRK43Cache, SSPMPRK43ConservativeCache,
+                         MPRK43ConstantCache, MPRK43Cache,
+                         SSPMPRK22ConstantCache, SSPMPRK22Cache,
+                         SSPMPRK43ConstantCache, SSPMPRK43Cache,
                          MPDeCConstantCache, MPDeCCache, MPDeCConservativeCache}
 
 function interp_summary(::Type{cacheType},

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -43,7 +43,7 @@ end
 #######################################################################################
 # interpolation specializations
 const MPRKCaches = Union{MPEConstantCache, MPECache, MPEConservativeCache,
-                         MPRK22ConstantCache, MPRK22Cache, MPRK22ConservativeCache,
+                         MPRK22ConstantCache, MPRK22Cache,
                          MPRK43ConstantCache, MPRK43Cache, MPRK43ConservativeCache,
                          SSPMPRK22ConstantCache, SSPMPRK22Cache, SSPMPRK22ConservativeCache,
                          SSPMPRK43ConstantCache, SSPMPRK43Cache, SSPMPRK43ConservativeCache,

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -43,6 +43,17 @@ end
     return P, nothing
 end
 
+@inline function evaluate_pds!(P, d, f::PDSFunction, u, p, t)
+    f.p(P, u, p, t) 
+    f.d(d, u, p, t) 
+    return nothing
+end
+
+@inline function evaluate_pds!(P, d, f::ConservativePDSFunction, u, p, t)
+    f.p(P, u, p, t)
+    return nothing
+end
+
 ### lincomb and lincomb! ###############################################
 # These functions are used to compute linear combinations of production 
 # matrices and/or destruction vectors.
@@ -79,6 +90,11 @@ end
         @.. broadcast=false dest=$expr
         return dest
     end
+end
+
+# in-place version for destruction terms of conservative PDS
+@inline function lincomb!(dest::Nothing, pairs...)
+    return nothing
 end
 
 # in-place version for sparse matrices 
@@ -140,7 +156,9 @@ end
     end
     return nothing
 end
-@inline function basic_patankar_step!(u, v, P, d, σ, dt, linsolve)
+
+#in-place version for PDSProblems
+@inline function basic_patankar_step!(u, v, P, d::AbstractArray, σ, dt, linsolve)
     b = linsolve.b
     b .= v
 
@@ -155,8 +173,8 @@ end
     return nothing
 end
 
-# conservative PDS
-@inline function basic_patankar_step_conservative!(u, v, P, σ, dt, linsolve)
+#in-place version for ConservativePDSProblems
+@inline function basic_patankar_step!(u, v, P, d::Nothing, σ, dt, linsolve)
     b = linsolve.b
     b .= v
 
@@ -738,17 +756,18 @@ end
     integrator.u = u
 end
 
-struct MPRK22Cache{uType, PType, tabType, F} <: MPRKMutableCache
+struct MPRK22Cache{uType, PType, dType, tabType, F} <: MPRKMutableCache
     tmp::uType
     P::PType
     P2::PType
-    D::uType
-    D2::uType
+    D::dType
+    D2::dType
     σ::uType
     tab::tabType
     linsolve::F
 end
 
+#=
 struct MPRK22ConservativeCache{uType, PType, tabType, F} <: MPRKMutableCache
     tmp::uType
     P::PType
@@ -757,6 +776,7 @@ struct MPRK22ConservativeCache{uType, PType, tabType, F} <: MPRKMutableCache
     tab::tabType
     linsolve::F
 end
+=#
 
 get_tmp_cache(integrator, ::MPRK22, cache::OrdinaryDiffEqMutableCache) = (cache.σ,)
 
@@ -786,7 +806,7 @@ function alg_cache(alg::MPRK22, u, rate_prototype, ::Type{uEltypeNoUnits},
                                                                  alias_b = true),
                         assumptions = LinearSolve.OperatorAssumptions(true))
 
-        MPRK22ConservativeCache(tmp, P, P2, σ,
+        MPRK22Cache(tmp, P, P2, nothing, nothing, σ,
                                 tab, #MPRK22ConstantCache
                                 linsolve)
     elseif f isa PDSFunction
@@ -807,7 +827,9 @@ function alg_cache(alg::MPRK22, u, rate_prototype, ::Type{uEltypeNoUnits},
     end
 end
 
-function initialize!(integrator, cache::Union{MPRK22Cache, MPRK22ConservativeCache})
+#function initialize!(integrator, cache::Union{MPRK22Cache, MPRK22ConservativeCache})
+#end
+function initialize!(integrator, cache::MPRK22Cache)
 end
 
 @muladd function perform_step!(integrator, cache::MPRK22Cache, repeat_step = false)
@@ -818,8 +840,8 @@ end
     # We use P2 to store the last evaluation of the PDS
     # as well as to store the system matrix of the linear system
 
-    f.p(P, uprev, p, t) # evaluate production terms
-    f.d(D, uprev, p, t) # evaluate nonconservative destruction terms
+    # evaluate production/destruction terms
+    evaluate_pds!(P, D, f, uprev, p, t)
     integrator.stats.nf += 1
 
     lincomb!(P2, a21, P)
@@ -838,8 +860,10 @@ end
         @.. broadcast=false σ=σ^(1 - 1 / a21) * u^(1 / a21) + small_constant
     end
 
-    f.p(P2, u, p, t + a21 * dt) # evaluate production terms
-    f.d(D2, u, p, t + a21 * dt) # evaluate nonconservative destruction terms
+    #f.p(P2, u, p, t + a21 * dt) # evaluate production terms
+    #f.d(D2, u, p, t + a21 * dt) # evaluate nonconservative destruction terms
+    # evaluate production/destruction terms
+    evaluate_pds!(P2, D2, f, u, p, t + a21*dt)
     integrator.stats.nf += 1
 
     lincomb!(P2, b1, P, b2, P2)
@@ -861,6 +885,7 @@ end
     integrator.EEst = integrator.opts.internalnorm(tmp, t)
 end
 
+#=
 @muladd function perform_step!(integrator, cache::MPRK22ConservativeCache,
                                repeat_step = false)
     (; t, dt, uprev, u, f, p) = integrator
@@ -906,6 +931,7 @@ end
                          False())
     integrator.EEst = integrator.opts.internalnorm(tmp, t)
 end
+=#
 
 ### MPRK43 #####################################################################################
 """

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -44,8 +44,8 @@ end
 end
 
 @inline function evaluate_pds!(P, d, f::PDSFunction, u, p, t)
-    f.p(P, u, p, t) 
-    f.d(d, u, p, t) 
+    f.p(P, u, p, t)
+    f.d(d, u, p, t)
     return nothing
 end
 
@@ -500,21 +500,23 @@ end
     integrator.u = u
 end
 
-struct MPECache{PType, uType, tabType, F} <: MPRKMutableCache
+struct MPECache{PType, dType, uType, tabType, F} <: MPRKMutableCache
     P::PType
-    D::uType
+    D::dType
     σ::uType
     tab::tabType
-    linsolve_rhs::uType  # stores rhs of linear system
+    #linsolve_rhs::uType  # stores rhs of linear system
     linsolve::F
 end
 
+#=
 struct MPEConservativeCache{PType, uType, tabType, F} <: MPRKMutableCache
     P::PType
     σ::uType
     tab::tabType
     linsolve::F
 end
+=#
 
 get_tmp_cache(integrator, ::MPE, cache::OrdinaryDiffEqMutableCache) = (cache.σ,)
 
@@ -538,7 +540,7 @@ function alg_cache(alg::MPE, u, rate_prototype, ::Type{uEltypeNoUnits},
                                                                  alias_b = true),
                         assumptions = LinearSolve.OperatorAssumptions(true))
 
-        MPEConservativeCache(P, σ, tab, linsolve)
+        MPECache(P, nothing, σ, tab, linsolve)
     elseif f isa PDSFunction
         linsolve_rhs = zero(u)
         # We use P to store the evaluation of the PDS
@@ -549,18 +551,19 @@ function alg_cache(alg::MPE, u, rate_prototype, ::Type{uEltypeNoUnits},
                                                                  alias_b = true),
                         assumptions = LinearSolve.OperatorAssumptions(true))
 
-        MPECache(P, similar(u), σ, tab, linsolve_rhs, linsolve)
+        #MPECache(P, similar(u), σ, tab, linsolve_rhs, linsolve)                
+        MPECache(P, similar(u), σ, tab, linsolve)
     else
         throw(ArgumentError("MPE can only be applied to production-destruction systems"))
     end
 end
 
-function initialize!(integrator, cache::Union{MPECache, MPEConservativeCache})
+function initialize!(integrator, cache::MPECache)
 end
 
 @muladd function perform_step!(integrator, cache::MPECache, repeat_step = false)
     (; t, dt, uprev, u, f, p) = integrator
-    (; P, D, σ, linsolve, linsolve_rhs) = cache
+    (; P, D, σ, linsolve) = cache
     (; small_constant) = cache.tab
 
     # We use P to store the evaluation of the PDS
@@ -568,8 +571,9 @@ end
 
     # We require the users to set unused entries to zero!
 
-    f.p(P, uprev, p, t) # evaluate production terms
-    f.d(D, uprev, p, t) # evaluate nonconservative destruction terms
+    #f.p(P, uprev, p, t) # evaluate production terms
+    #f.d(D, uprev, p, t) # evaluate nonconservative destruction terms
+    evaluate_pds!(P, D, f, uprev, p, t)
     integrator.stats.nf += 1
 
     # avoid division by zero due to zero Patankar weights
@@ -579,6 +583,7 @@ end
     integrator.stats.nsolve += 1
 end
 
+#=
 @muladd function perform_step!(integrator, cache::MPEConservativeCache, repeat_step = false)
     (; t, dt, uprev, u, f, p) = integrator
     (; P, σ, linsolve) = cache
@@ -598,6 +603,7 @@ end
     basic_patankar_step_conservative!(u, uprev, P, σ, dt, linsolve)
     integrator.stats.nsolve += 1
 end
+=#
 
 ### MPRK22 #####################################################################################
 """
@@ -807,8 +813,8 @@ function alg_cache(alg::MPRK22, u, rate_prototype, ::Type{uEltypeNoUnits},
                         assumptions = LinearSolve.OperatorAssumptions(true))
 
         MPRK22Cache(tmp, P, P2, nothing, nothing, σ,
-                                tab, #MPRK22ConstantCache
-                                linsolve)
+                    tab, #MPRK22ConstantCache
+                    linsolve)
     elseif f isa PDSFunction
         linprob = LinearProblem(P2, _vec(tmp))
         linsolve = init(linprob, alg.linsolve,
@@ -863,7 +869,7 @@ end
     #f.p(P2, u, p, t + a21 * dt) # evaluate production terms
     #f.d(D2, u, p, t + a21 * dt) # evaluate nonconservative destruction terms
     # evaluate production/destruction terms
-    evaluate_pds!(P2, D2, f, u, p, t + a21*dt)
+    evaluate_pds!(P2, D2, f, u, p, t + a21 * dt)
     integrator.stats.nf += 1
 
     lincomb!(P2, b1, P, b2, P2)
@@ -1227,20 +1233,21 @@ end
     integrator.u = u
 end
 
-struct MPRK43Cache{uType, PType, tabType, F} <: MPRKMutableCache
+struct MPRK43Cache{uType, PType, dType, tabType, F} <: MPRKMutableCache
     tmp::uType
     tmp2::uType
     P::PType
     P2::PType
     P3::PType
-    D::uType
-    D2::uType
-    D3::uType
+    D::dType
+    D2::dType
+    D3::dType
     σ::uType
     tab::tabType
     linsolve::F
 end
 
+#=
 struct MPRK43ConservativeCache{uType, PType, tabType, F} <: MPRKMutableCache
     tmp::uType
     tmp2::uType
@@ -1251,6 +1258,7 @@ struct MPRK43ConservativeCache{uType, PType, tabType, F} <: MPRKMutableCache
     tab::tabType
     linsolve::F
 end
+=#
 
 function get_tmp_cache(integrator, ::Union{MPRK43I, MPRK43II},
                        cache::OrdinaryDiffEqMutableCache)
@@ -1286,7 +1294,7 @@ function alg_cache(alg::Union{MPRK43I, MPRK43II}, u, rate_prototype, ::Type{uElt
                         alias = LinearSolve.LinearAliasSpecifier(; alias_A = true,
                                                                  alias_b = true),
                         assumptions = LinearSolve.OperatorAssumptions(true))
-        MPRK43ConservativeCache(tmp, tmp2, P, P2, P3, σ, tab, linsolve)
+        MPRK43Cache(tmp, tmp2, P, P2, P3, nothing, nothing, nothing, σ, tab, linsolve)
     elseif f isa PDSFunction
         D = similar(u)
         D2 = similar(u)
@@ -1304,7 +1312,7 @@ function alg_cache(alg::Union{MPRK43I, MPRK43II}, u, rate_prototype, ::Type{uElt
     end
 end
 
-function initialize!(integrator, cache::Union{MPRK43Cache, MPRK43ConservativeCache})
+function initialize!(integrator, cache::MPRK43Cache)
 end
 
 @muladd function perform_step!(integrator, cache::MPRK43Cache, repeat_step = false)
@@ -1315,8 +1323,9 @@ end
     # We use P3 to store the last evaluation of the PDS
     # as well as to store the system matrix of the linear system
 
-    f.p(P, uprev, p, t) # evaluate production terms
-    f.d(D, uprev, p, t) # evaluate nonconservative destruction terms
+    #f.p(P, uprev, p, t) # evaluate production terms
+    #f.d(D, uprev, p, t) # evaluate nonconservative destruction terms
+    evaluate_pds!(P, D, f, uprev, p, t)
     integrator.stats.nf += 1
 
     lincomb!(P3, a21, P)
@@ -1335,8 +1344,9 @@ end
 
     @.. broadcast=false σ=σ^(1 - q1) * u^q1 + small_constant
 
-    f.p(P2, u, p, t + c2 * dt) # evaluate production terms
-    f.d(D2, u, p, t + c2 * dt) # evaluate nonconservative destruction terms
+    #f.p(P2, u, p, t + c2 * dt) # evaluate production terms
+    #f.d(D2, u, p, t + c2 * dt) # evaluate nonconservative destruction terms
+    evaluate_pds!(P2, D2, f, u, p, t + c2 * dt)
     integrator.stats.nf += 1
 
     lincomb!(P3, a31, P, a32, P2)
@@ -1360,8 +1370,9 @@ end
     # avoid division by zero due to zero Patankar weights
     @.. broadcast=false σ=σ + small_constant
 
-    f.p(P3, u, p, t + c3 * dt) # evaluate production terms
-    f.d(D3, u, p, t + c3 * dt) # evaluate nonconservative destruction terms
+    #f.p(P3, u, p, t + c3 * dt) # evaluate production terms
+    #f.d(D3, u, p, t + c3 * dt) # evaluate nonconservative destruction terms
+    evaluate_pds!(P3, D3, f, u, p, t + c3 * dt)
     integrator.stats.nf += 1
 
     lincomb!(P3, b1, P, b2, P2, b3, P3)
@@ -1381,6 +1392,7 @@ end
     integrator.EEst = integrator.opts.internalnorm(tmp2, t)
 end
 
+#=
 @muladd function perform_step!(integrator, cache::MPRK43ConservativeCache,
                                repeat_step = false)
     (; t, dt, uprev, u, f, p) = integrator
@@ -1445,5 +1457,6 @@ end
                          False())
     integrator.EEst = integrator.opts.internalnorm(tmp2, t)
 end
+=#
 
 ########################################################################################

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -49,7 +49,7 @@ end
     return nothing
 end
 
-@inline function evaluate_pds!(P, d, f::ConservativePDSFunction, u, p, t)
+@inline function evaluate_pds!(P, d::nothing, f::ConservativePDSFunction, u, p, t)
     f.p(P, u, p, t)
     return nothing
 end
@@ -541,7 +541,6 @@ function alg_cache(alg::MPE, u, rate_prototype, ::Type{uEltypeNoUnits},
                                                                  alias_b = true),
                         assumptions = LinearSolve.OperatorAssumptions(true))
 
-        #MPECache(P, similar(u), σ, tab, linsolve_rhs, linsolve)                
         MPECache(P, similar(u), σ, tab, linsolve)
     else
         throw(ArgumentError("MPE can only be applied to production-destruction systems"))
@@ -789,8 +788,6 @@ function alg_cache(alg::MPRK22, u, rate_prototype, ::Type{uEltypeNoUnits},
     end
 end
 
-#function initialize!(integrator, cache::Union{MPRK22Cache, MPRK22ConservativeCache})
-#end
 function initialize!(integrator, cache::MPRK22Cache)
 end
 

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -505,18 +505,8 @@ struct MPECache{PType, dType, uType, tabType, F} <: MPRKMutableCache
     D::dType
     σ::uType
     tab::tabType
-    #linsolve_rhs::uType  # stores rhs of linear system
     linsolve::F
 end
-
-#=
-struct MPEConservativeCache{PType, uType, tabType, F} <: MPRKMutableCache
-    P::PType
-    σ::uType
-    tab::tabType
-    linsolve::F
-end
-=#
 
 get_tmp_cache(integrator, ::MPE, cache::OrdinaryDiffEqMutableCache) = (cache.σ,)
 
@@ -571,8 +561,7 @@ end
 
     # We require the users to set unused entries to zero!
 
-    #f.p(P, uprev, p, t) # evaluate production terms
-    #f.d(D, uprev, p, t) # evaluate nonconservative destruction terms
+    # evaluate production/destruction terms
     evaluate_pds!(P, D, f, uprev, p, t)
     integrator.stats.nf += 1
 
@@ -582,28 +571,6 @@ end
     basic_patankar_step!(u, uprev, P, D, σ, dt, linsolve)
     integrator.stats.nsolve += 1
 end
-
-#=
-@muladd function perform_step!(integrator, cache::MPEConservativeCache, repeat_step = false)
-    (; t, dt, uprev, u, f, p) = integrator
-    (; P, σ, linsolve) = cache
-    (; small_constant) = cache.tab
-
-    # We use P to store the evaluation of the PDS
-    # as well as to store the system matrix of the linear system
-
-    # We require the users to set unused entries to zero!
-
-    f.p(P, uprev, p, t) # evaluate production terms
-    integrator.stats.nf += 1
-
-    # avoid division by zero due to zero Patankar weights
-    @.. broadcast=false σ=uprev + small_constant
-
-    basic_patankar_step_conservative!(u, uprev, P, σ, dt, linsolve)
-    integrator.stats.nsolve += 1
-end
-=#
 
 ### MPRK22 #####################################################################################
 """
@@ -773,17 +740,6 @@ struct MPRK22Cache{uType, PType, dType, tabType, F} <: MPRKMutableCache
     linsolve::F
 end
 
-#=
-struct MPRK22ConservativeCache{uType, PType, tabType, F} <: MPRKMutableCache
-    tmp::uType
-    P::PType
-    P2::PType
-    σ::uType
-    tab::tabType
-    linsolve::F
-end
-=#
-
 get_tmp_cache(integrator, ::MPRK22, cache::OrdinaryDiffEqMutableCache) = (cache.σ,)
 
 # In-place
@@ -866,8 +822,6 @@ end
         @.. broadcast=false σ=σ^(1 - 1 / a21) * u^(1 / a21) + small_constant
     end
 
-    #f.p(P2, u, p, t + a21 * dt) # evaluate production terms
-    #f.d(D2, u, p, t + a21 * dt) # evaluate nonconservative destruction terms
     # evaluate production/destruction terms
     evaluate_pds!(P2, D2, f, u, p, t + a21 * dt)
     integrator.stats.nf += 1
@@ -890,54 +844,6 @@ end
                          False())
     integrator.EEst = integrator.opts.internalnorm(tmp, t)
 end
-
-#=
-@muladd function perform_step!(integrator, cache::MPRK22ConservativeCache,
-                               repeat_step = false)
-    (; t, dt, uprev, u, f, p) = integrator
-    (; tmp, P, P2, σ, linsolve) = cache
-    (; a21, b1, b2, small_constant) = cache.tab
-
-    # We use P2 to store the last evaluation of the PDS
-    # as well as to store the system matrix of the linear system
-    f.p(P, uprev, p, t) # evaluate production terms
-    integrator.stats.nf += 1
-
-    lincomb!(P2, a21, P)
-
-    # Avoid division by zero due to zero Patankar weights
-    @.. broadcast=false σ=uprev + small_constant
-
-    tmp .= uprev
-    basic_patankar_step_conservative!(u, tmp, P2, σ, dt, linsolve)
-    integrator.stats.nsolve += 1
-
-    if isone(a21)
-        @.. broadcast=false σ=u + small_constant
-    else
-        @.. broadcast=false σ=σ^(1 - 1 / a21) * u^(1 / a21) + small_constant
-    end
-
-    f.p(P2, u, p, t + a21 * dt) # evaluate production terms
-    integrator.stats.nf += 1
-
-    lincomb!(P2, b1, P, b2, P2)
-
-    basic_patankar_step_conservative!(u, tmp, P2, σ, dt, linsolve)
-    integrator.stats.nsolve += 1
-
-    # Now σ stores the error estimate
-    # If a21 = 1, then σ is the MPE approximation, i.e. suited for stiff problems.
-    # Otherwise, this is not clear.
-    @.. broadcast=false σ=u - σ
-
-    # Now tmp stores error residuals
-    calculate_residuals!(tmp, σ, uprev, u, integrator.opts.abstol,
-                         integrator.opts.reltol, integrator.opts.internalnorm, t,
-                         False())
-    integrator.EEst = integrator.opts.internalnorm(tmp, t)
-end
-=#
 
 ### MPRK43 #####################################################################################
 """
@@ -1247,19 +1153,6 @@ struct MPRK43Cache{uType, PType, dType, tabType, F} <: MPRKMutableCache
     linsolve::F
 end
 
-#=
-struct MPRK43ConservativeCache{uType, PType, tabType, F} <: MPRKMutableCache
-    tmp::uType
-    tmp2::uType
-    P::PType
-    P2::PType
-    P3::PType
-    σ::uType
-    tab::tabType
-    linsolve::F
-end
-=#
-
 function get_tmp_cache(integrator, ::Union{MPRK43I, MPRK43II},
                        cache::OrdinaryDiffEqMutableCache)
     (cache.σ,)
@@ -1323,8 +1216,7 @@ end
     # We use P3 to store the last evaluation of the PDS
     # as well as to store the system matrix of the linear system
 
-    #f.p(P, uprev, p, t) # evaluate production terms
-    #f.d(D, uprev, p, t) # evaluate nonconservative destruction terms
+    # evaluate production/destruction terms
     evaluate_pds!(P, D, f, uprev, p, t)
     integrator.stats.nf += 1
 
@@ -1344,8 +1236,7 @@ end
 
     @.. broadcast=false σ=σ^(1 - q1) * u^q1 + small_constant
 
-    #f.p(P2, u, p, t + c2 * dt) # evaluate production terms
-    #f.d(D2, u, p, t + c2 * dt) # evaluate nonconservative destruction terms
+    # evaluate production/destruction terms
     evaluate_pds!(P2, D2, f, u, p, t + c2 * dt)
     integrator.stats.nf += 1
 
@@ -1370,8 +1261,7 @@ end
     # avoid division by zero due to zero Patankar weights
     @.. broadcast=false σ=σ + small_constant
 
-    #f.p(P3, u, p, t + c3 * dt) # evaluate production terms
-    #f.d(D3, u, p, t + c3 * dt) # evaluate nonconservative destruction terms
+    # evaluate production/destruction terms
     evaluate_pds!(P3, D3, f, u, p, t + c3 * dt)
     integrator.stats.nf += 1
 
@@ -1391,72 +1281,5 @@ end
                          False())
     integrator.EEst = integrator.opts.internalnorm(tmp2, t)
 end
-
-#=
-@muladd function perform_step!(integrator, cache::MPRK43ConservativeCache,
-                               repeat_step = false)
-    (; t, dt, uprev, u, f, p) = integrator
-    (; tmp, tmp2, P, P2, P3, σ, linsolve) = cache
-    (; a21, a31, a32, b1, b2, b3, c2, c3, beta1, beta2, q1, q2, small_constant) = cache.tab
-
-    # We use P3 to store the last evaluation of the PDS
-    # as well as to store the system matrix of the linear system
-    f.p(P, uprev, p, t) # evaluate production terms
-    integrator.stats.nf += 1
-
-    lincomb!(P3, a21, P)
-
-    # avoid division by zero due to zero Patankar weights
-    @.. broadcast=false σ=uprev + small_constant
-
-    tmp .= uprev
-    basic_patankar_step_conservative!(u, tmp, P3, σ, dt, linsolve)
-    integrator.stats.nsolve += 1
-
-    if !(q1 ≈ q2)
-        tmp2 .= u #u2 in out-of-place version
-    end
-    integrator.stats.nsolve += 1
-
-    @.. broadcast=false σ=σ^(1 - q1) * u^q1 + small_constant
-
-    f.p(P2, u, p, t + c2 * dt) # evaluate production terms
-    integrator.stats.nf += 1
-
-    lincomb!(P3, a31, P, a32, P2)
-
-    basic_patankar_step_conservative!(u, tmp, P3, σ, dt, linsolve)
-    integrator.stats.nsolve += 1
-
-    if !(q1 ≈ q2)
-        @.. broadcast=false σ=(uprev + small_constant)^(1 - q2) * tmp2^q2 + small_constant
-    end
-
-    lincomb!(P3, beta1, P, beta2, P2)
-
-    basic_patankar_step_conservative!(σ, tmp, P3, σ, dt, linsolve)
-    integrator.stats.nsolve += 1
-
-    # avoid division by zero due to zero Patankar weights
-    @.. broadcast=false σ=σ + small_constant
-
-    f.p(P3, u, p, t + c3 * dt) # evaluate production terms
-    integrator.stats.nf += 1
-
-    lincomb!(P3, b1, P, b2, P2, b3, P3)
-
-    basic_patankar_step_conservative!(u, tmp, P3, σ, dt, linsolve)
-    integrator.stats.nsolve += 1
-
-    # Now tmp stores the error estimate
-    @.. broadcast=false tmp=u - σ
-
-    # Now tmp2 stores error residuals
-    calculate_residuals!(tmp2, tmp, uprev, u, integrator.opts.abstol,
-                         integrator.opts.reltol, integrator.opts.internalnorm, t,
-                         False())
-    integrator.EEst = integrator.opts.internalnorm(tmp2, t)
-end
-=#
 
 ########################################################################################

--- a/src/mprk.jl
+++ b/src/mprk.jl
@@ -49,7 +49,7 @@ end
     return nothing
 end
 
-@inline function evaluate_pds!(P, d::nothing, f::ConservativePDSFunction, u, p, t)
+@inline function evaluate_pds!(P, d::Nothing, f::ConservativePDSFunction, u, p, t)
     f.p(P, u, p, t)
     return nothing
 end

--- a/src/sspmprk.jl
+++ b/src/sspmprk.jl
@@ -185,17 +185,6 @@ struct SSPMPRK22Cache{uType, PType, dType, tabType, F} <: MPRKMutableCache
     linsolve::F
 end
 
-#=
-struct SSPMPRK22ConservativeCache{uType, PType, tabType, F} <: MPRKMutableCache
-    tmp::uType
-    P::PType
-    P2::PType
-    σ::uType
-    tab::tabType
-    linsolve::F
-end
-=#
-
 get_tmp_cache(integrator, ::SSPMPRK22, cache::OrdinaryDiffEqMutableCache) = (cache.σ,)
 
 # In-place
@@ -253,8 +242,7 @@ end
     # We use P2 to store the last evaluation of the PDS
     # as well as to store the system matrix of the linear system
 
-    #f.p(P, uprev, p, t) # evaluate production terms
-    #f.d(D, uprev, p, t) # evaluate nonconservative destruction terms
+    # evaluate production/destruction terms
     evaluate_pds!(P, D, f, uprev, p, t)
     integrator.stats.nf += 1
 
@@ -275,8 +263,7 @@ end
         @.. broadcast=false σ=σ^(1 - s) * u^s + small_constant
     end
 
-    #f.p(P2, u, p, t + b10 * dt) # evaluate production terms
-    #f.d(D2, u, p, t + b10 * dt) # evaluate nonconservative destruction terms
+    # evaluate production/destruction terms
     evaluate_pds!(P2, D2, f, u, p, t + b10 * dt)
     integrator.stats.nf += 1
 
@@ -303,60 +290,6 @@ end
                          False())
     integrator.EEst = integrator.opts.internalnorm(tmp, t)
 end
-
-#=
-@muladd function perform_step!(integrator, cache::SSPMPRK22ConservativeCache,
-                               repeat_step = false)
-    (; t, dt, uprev, u, f, p) = integrator
-    (; tmp, P, P2, σ, linsolve) = cache
-    (; a21, a10, a20, b10, b20, b21, s, τ, small_constant) = cache.tab
-
-    # We use P2 to store the last evaluation of the PDS
-    # as well as to store the system matrix of the linear system
-    f.p(P, uprev, p, t) # evaluate production terms
-    integrator.stats.nf += 1
-
-    lincomb!(P2, b10, P)
-
-    # Avoid division by zero due to zero Patankar weights
-    @.. broadcast=false σ=uprev + small_constant
-
-    # tmp holds the right hand side of the linear system
-    @.. broadcast=false tmp=a10 * uprev
-    basic_patankar_step_conservative!(u, tmp, P2, σ, dt, linsolve)
-    integrator.stats.nsolve += 1
-
-    if isone(s)
-        @.. broadcast=false σ=u + small_constant
-    else
-        @.. broadcast=false σ=σ^(1 - s) * u^s + small_constant
-    end
-
-    f.p(P2, u, p, t + b10 * dt) # evaluate production terms
-    integrator.stats.nf += 1
-
-    lincomb!(P2, b20, P, b21, P2)
-
-    @.. broadcast=false tmp=a20 * uprev + a21 * u
-    basic_patankar_step_conservative!(u, tmp, P2, σ, dt, linsolve)
-    integrator.stats.nsolve += 1
-
-    # Unless τ = 1, σ is not a first order approximation, since
-    # σ = uprev + τ * dt *(P^n − D^n) + O(dt^2), see (2.7) in
-    # https://doi.org/10.1007/s10915-018-0852-1.
-    # But we can compute a 1st order approximation as σ2 = (σ - uprev) / τ + uprev.
-    # σ2 may become negative, but still can be used for error estimation.
-
-    # Now σ stores the error estimate
-    @.. broadcast=false σ=u - (σ - uprev) / τ - uprev
-
-    # Now tmp stores error residuals
-    calculate_residuals!(tmp, σ, uprev, u, integrator.opts.abstol,
-                         integrator.opts.reltol, integrator.opts.internalnorm, t,
-                         False())
-    integrator.EEst = integrator.opts.internalnorm(tmp, t)
-end
-=#
 
 """
     SSPMPRK43([linsolve = ..., small_constant = ...])
@@ -602,20 +535,6 @@ struct SSPMPRK43Cache{uType, PType, dType, tabType, F} <: MPRKMutableCache
     linsolve::F
 end
 
-#=
-struct SSPMPRK43ConservativeCache{uType, PType, tabType, F} <: MPRKMutableCache
-    tmp::uType
-    tmp2::uType
-    P::PType
-    P2::PType
-    P3::PType
-    σ::uType
-    ρ::uType
-    tab::tabType
-    linsolve::F
-end
-=#
-
 get_tmp_cache(integrator, ::SSPMPRK43, cache::OrdinaryDiffEqMutableCache) = (cache.σ,)
 
 # In-place
@@ -674,8 +593,7 @@ end
     # We use P3 to store the last evaluation of the PDS
     # as well as to store the system matrix of the linear system
 
-    #f.p(P, uprev, p, t) # evaluate production terms
-    #f.d(D, uprev, p, t) # evaluate nonconservative destruction terms
+    # evaluate production/destruction terms
     evaluate_pds!(P, D, f, uprev, p, t)
     integrator.stats.nf += 1
 
@@ -695,8 +613,7 @@ end
     @.. broadcast=false ρ=n1 * u + n2 * u^2 / σ
     @.. broadcast=false ρ=ρ + small_constant
 
-    #f.p(P2, u, p, t + β10 * dt) # evaluate production terms
-    #f.d(D2, u, p, t + β10 * dt) # evaluate nonconservative destruction terms
+    # evaluate production/destruction terms
     evaluate_pds!(P2, D2, f, u, p, t + β10 * dt)
     integrator.stats.nf += 1
 
@@ -739,8 +656,7 @@ end
     # avoid division by zero due to zero Patankar weights
     @.. broadcast=false σ=σ + small_constant
 
-    #f.p(P3, u, p, t + c3 * dt) # evaluate production terms
-    #f.d(D3, u, p, t + c3 * dt) # evaluate nonconservative destruction terms
+    # evaluate production/destruction terms
     evaluate_pds!(P3, D3, f, u, p, t + c3 * dt)
     integrator.stats.nf += 1
 
@@ -765,78 +681,3 @@ end
     integrator.EEst = integrator.opts.internalnorm(tmp2, t)
     =#
 end
-
-#=
-@muladd function perform_step!(integrator, cache::SSPMPRK43ConservativeCache,
-                               repeat_step = false)
-    (; t, dt, uprev, u, f, p) = integrator
-    (; tmp, tmp2, P, P2, P3, σ, ρ, linsolve) = cache
-    (; n1, n2, z, η1, η2, η3, η4, s, α10, α20, α21, α30, α31, α32, β10, β20, β21, β30, β31, β32, c3, small_constant) = cache.tab
-
-    # We use P3 to store the last evaluation of the PDS
-    # as well as to store the system matrix of the linear system
-    f.p(P, uprev, p, t) # evaluate production terms
-    integrator.stats.nf += 1
-
-    lincomb!(P3, β10, P)
-
-    # avoid division by zero due to zero Patankar weights
-    @.. broadcast=false σ=uprev + small_constant
-
-    # tmp holds the right hand side of the linear system
-    @.. broadcast=false tmp=α10 * uprev
-
-    basic_patankar_step_conservative!(u, tmp, P3, σ, dt, linsolve)
-    integrator.stats.nsolve += 1
-
-    tmp2 .= u
-
-    @.. broadcast=false ρ=n1 * u + n2 * u^2 / σ
-    @.. broadcast=false ρ=ρ + small_constant
-
-    f.p(P2, u, p, t + β10 * dt) # evaluate production terms
-    integrator.stats.nf += 1
-
-    lincomb!(P3, β20, P, β21, P2)
-
-    @.. broadcast=false tmp=α20 * uprev + α21 * tmp2
-
-    basic_patankar_step_conservative!(u, tmp, P3, ρ, dt, linsolve)
-    integrator.stats.nsolve += 1
-
-    @.. broadcast=false σ=σ^(1 - s) * tmp2^s + small_constant
-
-    lincomb!(P3, η3, P, η4, P2)
-
-    @.. broadcast=false tmp=η1 * uprev + η2 * tmp2
-
-    basic_patankar_step_conservative!(σ, tmp, P3, σ, dt, linsolve)
-    integrator.stats.nsolve += 1
-
-    @.. broadcast=false σ=σ + z * uprev * u / ρ
-    # avoid division by zero due to zero Patankar weights
-    @.. broadcast=false σ=σ + small_constant
-
-    f.p(P3, u, p, t + c3 * dt) # evaluate production terms
-    integrator.stats.nf += 1
-
-    lincomb!(P3, β30, P, β31, P2, β32, P3)
-
-    @.. broadcast=false tmp=α30 * uprev + α31 * tmp2 + α32 * u
-    basic_patankar_step_conservative!(u, tmp, P3, σ, dt, linsolve)
-    integrator.stats.nsolve += 1
-
-    #TODO: Figure out if a second order approximation of the solution
-    # is hidden somewhere.
-    #=
-    # Now tmp stores the error estimate
-    @.. broadcast=false tmp=u - σ
-
-    # Now tmp2 stores error residuals
-    calculate_residuals!(tmp2, tmp, uprev, u, integrator.opts.abstol,
-                         integrator.opts.reltol, integrator.opts.internalnorm, t,
-                         False())
-    integrator.EEst = integrator.opts.internalnorm(tmp2, t)
-    =#
-end
-=#

--- a/src/sspmprk.jl
+++ b/src/sspmprk.jl
@@ -174,17 +174,18 @@ end
     integrator.u = u
 end
 
-struct SSPMPRK22Cache{uType, PType, tabType, F} <: MPRKMutableCache
+struct SSPMPRK22Cache{uType, PType, dType, tabType, F} <: MPRKMutableCache
     tmp::uType
     P::PType
     P2::PType
-    D::uType
-    D2::uType
+    D::dType
+    D2::dType
     σ::uType
     tab::tabType
     linsolve::F
 end
 
+#=
 struct SSPMPRK22ConservativeCache{uType, PType, tabType, F} <: MPRKMutableCache
     tmp::uType
     P::PType
@@ -193,6 +194,7 @@ struct SSPMPRK22ConservativeCache{uType, PType, tabType, F} <: MPRKMutableCache
     tab::tabType
     linsolve::F
 end
+=#
 
 get_tmp_cache(integrator, ::SSPMPRK22, cache::OrdinaryDiffEqMutableCache) = (cache.σ,)
 
@@ -219,9 +221,9 @@ function alg_cache(alg::SSPMPRK22, u, rate_prototype, ::Type{uEltypeNoUnits},
                                                                  alias_b = true),
                         assumptions = LinearSolve.OperatorAssumptions(true))
 
-        SSPMPRK22ConservativeCache(tmp, P, P2, σ,
-                                   tab, #MPRK22ConstantCache
-                                   linsolve)
+        SSPMPRK22Cache(tmp, P, P2, nothing, nothing, σ,
+                       tab, #MPRK22ConstantCache
+                       linsolve)
     elseif f isa PDSFunction
         linprob = LinearProblem(P2, _vec(tmp))
         linsolve = init(linprob, alg.linsolve,
@@ -240,7 +242,7 @@ function alg_cache(alg::SSPMPRK22, u, rate_prototype, ::Type{uEltypeNoUnits},
     end
 end
 
-function initialize!(integrator, cache::Union{SSPMPRK22Cache, SSPMPRK22ConservativeCache})
+function initialize!(integrator, cache::SSPMPRK22Cache)
 end
 
 @muladd function perform_step!(integrator, cache::SSPMPRK22Cache, repeat_step = false)
@@ -251,8 +253,9 @@ end
     # We use P2 to store the last evaluation of the PDS
     # as well as to store the system matrix of the linear system
 
-    f.p(P, uprev, p, t) # evaluate production terms
-    f.d(D, uprev, p, t) # evaluate nonconservative destruction terms
+    #f.p(P, uprev, p, t) # evaluate production terms
+    #f.d(D, uprev, p, t) # evaluate nonconservative destruction terms
+    evaluate_pds!(P, D, f, uprev, p, t)
     integrator.stats.nf += 1
 
     lincomb!(P2, b10, P)
@@ -272,8 +275,9 @@ end
         @.. broadcast=false σ=σ^(1 - s) * u^s + small_constant
     end
 
-    f.p(P2, u, p, t + b10 * dt) # evaluate production terms
-    f.d(D2, u, p, t + b10 * dt) # evaluate nonconservative destruction terms
+    #f.p(P2, u, p, t + b10 * dt) # evaluate production terms
+    #f.d(D2, u, p, t + b10 * dt) # evaluate nonconservative destruction terms
+    evaluate_pds!(P2, D2, f, u, p, t + b10 * dt)
     integrator.stats.nf += 1
 
     lincomb!(P2, b20, P, b21, P2)
@@ -300,6 +304,7 @@ end
     integrator.EEst = integrator.opts.internalnorm(tmp, t)
 end
 
+#=
 @muladd function perform_step!(integrator, cache::SSPMPRK22ConservativeCache,
                                repeat_step = false)
     (; t, dt, uprev, u, f, p) = integrator
@@ -351,6 +356,7 @@ end
                          False())
     integrator.EEst = integrator.opts.internalnorm(tmp, t)
 end
+=#
 
 """
     SSPMPRK43([linsolve = ..., small_constant = ...])
@@ -581,21 +587,22 @@ end
     integrator.u = u
 end
 
-struct SSPMPRK43Cache{uType, PType, tabType, F} <: MPRKMutableCache
+struct SSPMPRK43Cache{uType, PType, dType, tabType, F} <: MPRKMutableCache
     tmp::uType
     tmp2::uType
     P::PType
     P2::PType
     P3::PType
-    D::uType
-    D2::uType
-    D3::uType
+    D::dType
+    D2::dType
+    D3::dType
     σ::uType
     ρ::uType
     tab::tabType
     linsolve::F
 end
 
+#=
 struct SSPMPRK43ConservativeCache{uType, PType, tabType, F} <: MPRKMutableCache
     tmp::uType
     tmp2::uType
@@ -607,6 +614,7 @@ struct SSPMPRK43ConservativeCache{uType, PType, tabType, F} <: MPRKMutableCache
     tab::tabType
     linsolve::F
 end
+=#
 
 get_tmp_cache(integrator, ::SSPMPRK43, cache::OrdinaryDiffEqMutableCache) = (cache.σ,)
 
@@ -637,7 +645,7 @@ function alg_cache(alg::SSPMPRK43, u, rate_prototype, ::Type{uEltypeNoUnits},
                         alias = LinearSolve.LinearAliasSpecifier(; alias_A = true,
                                                                  alias_b = true),
                         assumptions = LinearSolve.OperatorAssumptions(true))
-        SSPMPRK43ConservativeCache(tmp, tmp2, P, P2, P3, σ, ρ, tab, linsolve)
+        SSPMPRK43Cache(tmp, tmp2, P, P2, P3, nothing, nothing, nothing, σ, ρ, tab, linsolve)
     elseif f isa PDSFunction
         D = similar(u)
         D2 = similar(u)
@@ -655,7 +663,7 @@ function alg_cache(alg::SSPMPRK43, u, rate_prototype, ::Type{uEltypeNoUnits},
     end
 end
 
-function initialize!(integrator, cache::Union{SSPMPRK43ConservativeCache, SSPMPRK43Cache})
+function initialize!(integrator, cache::SSPMPRK43Cache)
 end
 
 @muladd function perform_step!(integrator, cache::SSPMPRK43Cache, repeat_step = false)
@@ -666,8 +674,9 @@ end
     # We use P3 to store the last evaluation of the PDS
     # as well as to store the system matrix of the linear system
 
-    f.p(P, uprev, p, t) # evaluate production terms
-    f.d(D, uprev, p, t) # evaluate nonconservative destruction terms
+    #f.p(P, uprev, p, t) # evaluate production terms
+    #f.d(D, uprev, p, t) # evaluate nonconservative destruction terms
+    evaluate_pds!(P, D, f, uprev, p, t)
     integrator.stats.nf += 1
 
     lincomb!(P3, β10, P)
@@ -686,8 +695,9 @@ end
     @.. broadcast=false ρ=n1 * u + n2 * u^2 / σ
     @.. broadcast=false ρ=ρ + small_constant
 
-    f.p(P2, u, p, t + β10 * dt) # evaluate production terms
-    f.d(D2, u, p, t + β10 * dt) # evaluate nonconservative destruction terms
+    #f.p(P2, u, p, t + β10 * dt) # evaluate production terms
+    #f.d(D2, u, p, t + β10 * dt) # evaluate nonconservative destruction terms
+    evaluate_pds!(P2, D2, f, u, p, t + β10 * dt)
     integrator.stats.nf += 1
 
     lincomb!(P3, β20, P, β21, P2)
@@ -729,8 +739,9 @@ end
     # avoid division by zero due to zero Patankar weights
     @.. broadcast=false σ=σ + small_constant
 
-    f.p(P3, u, p, t + c3 * dt) # evaluate production terms
-    f.d(D3, u, p, t + c3 * dt) # evaluate nonconservative destruction terms
+    #f.p(P3, u, p, t + c3 * dt) # evaluate production terms
+    #f.d(D3, u, p, t + c3 * dt) # evaluate nonconservative destruction terms
+    evaluate_pds!(P3, D3, f, u, p, t + c3 * dt)
     integrator.stats.nf += 1
 
     lincomb!(P3, β30, P, β31, P2, β32, P3)
@@ -755,6 +766,7 @@ end
     =#
 end
 
+#=
 @muladd function perform_step!(integrator, cache::SSPMPRK43ConservativeCache,
                                repeat_step = false)
     (; t, dt, uprev, u, f, p) = integrator
@@ -827,3 +839,4 @@ end
     integrator.EEst = integrator.opts.internalnorm(tmp2, t)
     =#
 end
+=#


### PR DESCRIPTION
**Problem:** Currently, every algorithm requires two separate in-place implementations: one for `ConservativePDSProblem` and one for `PDSProblem`. Because the latter requires additional destruction vectors, they use different cache structures, leading to significant code duplication.

**Solution:** This PR consolidates these implementations by adopting the strategy used in the out-of-place version. By using Nothing for destruction vectors in ConservativePDSProblems and leveraging multiple dispatch, we can now use a single unified code path.

**Impact:**
- Reduces code duplication significantly.

- Simplifies maintenance and the implementation of future algorithms.

-  Consistent behavior between in-place and out-of-place APIs.

